### PR TITLE
Remove unused semicolon.

### DIFF
--- a/flatdata-cpp/include/flatdata/MemoryResourceStorage.h
+++ b/flatdata-cpp/include/flatdata/MemoryResourceStorage.h
@@ -185,8 +185,8 @@ dump_resource( const std::string& key,
         }
     }
     out << "|" << line << "|" << std::endl << std::endl;
-};
-}  // helpers
+}
+}  // namespace helpers
 
 inline bool
 MemoryResourceStorage::exists( const char* key )


### PR DESCRIPTION
Fixes `warning: extra ';'`.