### PR TITLE
Do no rely on the fact that the lib is configured with root cmake.

### DIFF
--- a/flatdata-cpp/test/CMakeLists.txt
+++ b/flatdata-cpp/test/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(GTest QUIET)
 find_package(Threads)
 if(NOT GTest_FOUND)
     set(USE_VENDOR_GTEST ON)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/vendor/gtest ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../vendor/gtest ${CMAKE_CURRENT_BINARY_DIR}/gtest)
 endif()
 
 file(GLOB TEST_FLATDATA_SOURCES "*.cpp")


### PR DESCRIPTION
It is possible that the library is included in a bigger project,
and so, the root cmake of the library is not the root of the
project configuration. In this case, the discovery of gtest breaks.