### PR TITLE
Add optional archive to coappearances example.

### DIFF
--- a/examples/coappearances/coappearances.cpp
+++ b/examples/coappearances/coappearances.cpp
@@ -275,16 +275,15 @@ calculate_num_connected_components( co::Graph graph )
 void
 calculate( const char* archive_path )
 {
-    auto graph = co::Graph::open( flatdata::FileResourceStorage::create( archive_path ) );
+    std::shared_ptr< flatdata::FileResourceStorage > storage
+        = flatdata::FileResourceStorage::create( archive_path );
+    auto graph = co::Graph::open( storage );
     if ( !graph )
     {
         std::cerr << graph.describe( ) << std::endl;
         throw std::runtime_error( std::string( "Could not open graph at: " ) + archive_path );
     }
-
-    std::string subarchive_path = std::string( archive_path ) + "/statistics";
-    auto builder = co::StatisticsBuilder::open(
-        flatdata::FileResourceStorage::create( subarchive_path.c_str( ) ) );
+    auto builder = co::GraphBuilder::open( storage ).statistics( );
 
     flatdata::Vector< co::Degree > vertex_degrees( graph.vertices( ).size( ) );
     for ( auto e : graph.edges( ) )

--- a/examples/coappearances/coappearances.cpp
+++ b/examples/coappearances/coappearances.cpp
@@ -237,21 +237,20 @@ calculate_num_connected_components( co::Graph graph )
 {
     size_t num_connected_components = 0;
 
-    std::vector< bool > visited( graph.vertices( ).size( ) );
-    uint32_t num_visited = 0;
+    std::vector< bool > seen( graph.vertices( ).size( ) );
     std::vector< uint32_t > stack;
 
     for ( uint32_t vertex_ref = 0; vertex_ref < graph.vertices( ).size( ); ++vertex_ref )
     {
-        // skip already visited vertices
-        if ( visited[ vertex_ref ] )
+        // skip already seen vertices
+        if ( seen[ vertex_ref ] )
         {
             continue;
         }
 
         stack.clear( );
         stack.push_back( vertex_ref );
-        visited[ vertex_ref ] = true;
+        seen[ vertex_ref ] = true;
 
         // depth first search
         while ( !stack.empty( ) )
@@ -260,10 +259,10 @@ calculate_num_connected_components( co::Graph graph )
             stack.pop_back( );
             for ( auto neighbor_ref : get_neighbors( graph, vertex_ref ) )
             {
-                if ( !visited[ neighbor_ref ] )
+                if ( !seen[ neighbor_ref ] )
                 {
                     stack.push_back( neighbor_ref );
-                    visited[ neighbor_ref ] = true;
+                    seen[ neighbor_ref ] = true;
                 }
             }
         }

--- a/examples/coappearances/coappearances.flatdata
+++ b/examples/coappearances/coappearances.flatdata
@@ -129,5 +129,26 @@ archive Graph {
 
     // All strings contained in the data separated by '\0'.
     strings: raw_data;
+
+    // Optional archive containing calculated statistics.
+    @optional
+    calculated_data : archive CalculatedData;
+}
+
+struct Invariants {
+    max_degree : u32 : 16;
+    max_degree_ref : u32 : 16;
+    min_degree : u32 : 16;
+    min_degree_ref : u32 : 16;
+    num_connected_components : u32 : 16;
+}
+
+struct Degree {
+    value : u32 : 16;
+}
+
+archive CalculatedData {
+    invariants : Invariants;
+    vertex_degrees : vector< Degree >;
 }
 } // namespace graph

--- a/examples/coappearances/coappearances.flatdata
+++ b/examples/coappearances/coappearances.flatdata
@@ -132,7 +132,7 @@ archive Graph {
 
     // Optional archive containing calculated statistics.
     @optional
-    calculated_data : archive CalculatedData;
+    statistics : archive Statistics;
 }
 
 struct Invariants {
@@ -147,8 +147,11 @@ struct Degree {
     value : u32 : 16;
 }
 
-archive CalculatedData {
+@bound_implicitly( characters: Graph.vertices, vertex_degrees )
+archive Statistics {
     invariants : Invariants;
+
+    // indexed by `vertices`
     vertex_degrees : vector< Degree >;
 }
 } // namespace graph


### PR DESCRIPTION
Extend the coappearances example to cover optional subarchives. Ideally, the coappearances example will cover all aspects of flatdata grammar.

The example also shows that optional subarchives can be added later to the main archive.