### PR TITLE
Use flatdata generator to create an archive's schema files

### DIFF
--- a/flatdata-cpp/include/flatdata/internal/ResourceStorage.inl
+++ b/flatdata-cpp/include/flatdata/internal/ResourceStorage.inl
@@ -142,6 +142,7 @@ ResourceStorage::read_and_check_schema( const char* resource_name, const char* e
 
     std::string stored_schema( reinterpret_cast< const char* >( schema.data( ) ),
                                schema.size_in_bytes( ) );
+
     if ( stored_schema != expected_schema )
     {
         return MemoryDescriptor( );

--- a/flatdata-cpp/test/SerializedStructTest.cpp
+++ b/flatdata-cpp/test/SerializedStructTest.cpp
@@ -87,5 +87,5 @@ TEST( SerializedStructTest, SignedStructWorks )
 
 TEST( SerializedStructTest, Schema )
 {
-    ASSERT_TRUE( SimpleStruct::schema( ) != OtherSimpleStruct::schema( ) );
+    ASSERT_STRNE( SimpleStruct::schema( ).c_str( ), OtherSimpleStruct::schema( ).c_str( ) );
 }

--- a/flatdata-go/backward-compatibility-tests/Gopkg.lock
+++ b/flatdata-go/backward-compatibility-tests/Gopkg.lock
@@ -22,6 +22,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a9dd4821c4522b2069722c1be94b191e7aff1736aeb5c12ab0070f87cdbc5af2"
+  inputs-digest = "0a81cdd8b28938307cd5d3941bfdb99c2b2a04aac9c0cb95558335aaab9ea4bd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/flatdata-go/backward-compatibility-tests/test_data.go
+++ b/flatdata-go/backward-compatibility-tests/test_data.go
@@ -41,13 +41,24 @@ func getVectorPayload() []byte {
 }
 
 func getVectorSchema() string {
-	return `namespace backwardcompatibility { struct SignedStruct {
-        a : i16 : 5;
-        b : u32 : 32;
-        c : i32 : 7;
-        d : u32 : 32;
-    } }
-namespace backwardcompatibility { resource_b: vector< SignedStruct >; }`
+	return `namespace backwardcompatibility {
+struct SignedStruct
+{
+    a : i16 : 5;
+    b : u32 : 32;
+    c : i32 : 7;
+    d : u32 : 32;
+}
+}
+
+namespace backwardcompatibility {
+archive BackwardCompatibilityTest
+{
+    resource_b : vector< .backwardcompatibility.SignedStruct >;
+}
+}
+
+`
 }
 
 func getMultivectorResourcePayload() []byte {
@@ -74,18 +85,32 @@ func getMultivectorIndexPayload() []byte {
 }
 
 func getMultivectorSchema() string {
-	return `namespace backwardcompatibility { struct SimpleStruct {
-        a : u32 : 32;
-        b : u32 : 32;
-    } }
-namespace backwardcompatibility { struct SignedStruct {
-        a : i16 : 5;
-        b : u32 : 32;
-        c : i32 : 7;
-        d : u32 : 32;
-    } }
-namespace _builtin.multivector { struct IndexType33 { value : u64 : 33; } }
-namespace backwardcompatibility { resource_c: multivector< 33, SimpleStruct, SignedStruct >; }`
+	return `namespace backwardcompatibility {
+struct SignedStruct
+{
+    a : i16 : 5;
+    b : u32 : 32;
+    c : i32 : 7;
+    d : u32 : 32;
+}
+}
+
+namespace backwardcompatibility {
+struct SimpleStruct
+{
+    a : u32 : 32;
+    b : u32 : 32;
+}
+}
+
+namespace backwardcompatibility {
+archive BackwardCompatibilityTest
+{
+    resource_c : multivector< 33, .backwardcompatibility.SimpleStruct, .backwardcompatibility.SignedStruct >;
+}
+}
+
+`
 }
 
 func getRawDataPayload() []byte {
@@ -97,7 +122,14 @@ func getRawDataPayload() []byte {
 }
 
 func getRawDataSchema() string {
-	return "namespace backwardcompatibility { resource_d: raw_data; }"
+	return `namespace backwardcompatibility {
+archive BackwardCompatibilityTest
+{
+    resource_d : raw_data;
+}
+}
+
+`
 }
 
 func getInstanceDataPayload() []byte {
@@ -110,11 +142,22 @@ func getInstanceDataPayload() []byte {
 }
 
 func getInstanceSchema() string {
-	return `namespace backwardcompatibility { struct SignedStruct {
-        a : i16 : 5;
-        b : u32 : 32;
-        c : i32 : 7;
-        d : u32 : 32;
-    } }
-namespace backwardcompatibility { resource_a: SignedStruct; }`
+	return `namespace backwardcompatibility {
+struct SignedStruct
+{
+    a : i16 : 5;
+    b : u32 : 32;
+    c : i32 : 7;
+    d : u32 : 32;
+}
+}
+
+namespace backwardcompatibility {
+archive BackwardCompatibilityTest
+{
+    resource_a : .backwardcompatibility.SignedStruct;
+}
+}
+
+`
 }

--- a/generator/tree/builder.py
+++ b/generator/tree/builder.py
@@ -91,7 +91,6 @@ def _build_node_tree(definition):
         for collection, cls in parsed_items:
             for start, item, end in collection:
                 target_namespace.insert(cls.create(properties=item,
-                                                   own_schema=definition[start:end],
                                                    definition=definition))
 
         roots.append(root_namespace)

--- a/generator/tree/nodes/archive.py
+++ b/generator/tree/nodes/archive.py
@@ -5,7 +5,7 @@ import generator.tree.nodes.resources as resources
 
 class _ResourceFactory(object):
     @staticmethod
-    def _create_resource_object(properties, own_schema):
+    def _create_resource_object(properties):
         type = properties.type
         if 'vector' in type:
             cls = resources.Vector
@@ -21,32 +21,29 @@ class _ResourceFactory(object):
             raise UnexpectedResourceType(properties.type)
 
         assert issubclass(cls, resources.ResourceBase)
-        return cls.create(properties=properties, own_schema=own_schema)
+        return cls.create(properties=properties)
 
     @staticmethod
-    def create_resource(properties, own_schema):
-        result = _ResourceFactory._create_resource_object(properties=properties,
-                                                          own_schema=own_schema)
+    def create_resource(properties):
+        result = _ResourceFactory._create_resource_object(properties=properties)
         for r in result.create_references():
             result.insert(r)
         return result
 
 
 class Archive(Node):
-    def __init__(self, name, properties=None, own_schema=None):
+    def __init__(self, name, properties=None):
         super(Archive, self).__init__(name=name, properties=properties)
-        self._own_schema = own_schema
 
     @staticmethod
-    def create(properties, own_schema, definition):
-        result = Archive(name=properties.name, properties=properties, own_schema=own_schema)
+    def create(properties, definition):
+        result = Archive(name=properties.name, properties=properties)
         for start, r, end in properties.resources:
-            result.insert(_ResourceFactory.create_resource(r, definition[start:end]))
+            result.insert(_ResourceFactory.create_resource(r))
 
         for d in properties.decorations:
             if "bound_implicitly" in d:
-                bound = resources.BoundResource.create(properties=d.bound_implicitly,
-                                                       own_schema=None)
+                bound = resources.BoundResource.create(properties=d.bound_implicitly)
                 for ref in bound.create_references():
                     bound.insert(ref)
                 result.insert(bound)

--- a/generator/tree/nodes/node.py
+++ b/generator/tree/nodes/node.py
@@ -5,6 +5,7 @@
 
 from collections import OrderedDict
 from generator.tree.errors import SymbolRedefinition
+from copy import copy
 
 
 class Node(object):
@@ -178,6 +179,21 @@ class Node(object):
         while result.parent is not None:
             result = result._parent
         return result
+
+    def extract_subtree(self):
+        """
+        Extract the subtree of node (some nodes are copied)
+        Also copies the path to the root of the tree
+        """
+
+        new_root = copy(self)
+        while new_root._parent != None:
+            parent = copy(new_root._parent)
+            parent._children = OrderedDict()
+            new_root._parent = parent;
+            parent._children[new_root.name] = new_root
+            new_root = parent
+        return new_root
 
     def insert(self, *nodes):
         """

--- a/generator/tree/nodes/resources/archive.py
+++ b/generator/tree/nodes/resources/archive.py
@@ -3,16 +3,15 @@ from generator.tree.nodes.references import ArchiveReference
 
 
 class Archive(ResourceBase):
-    def __init__(self, name, properties=None, target=None, own_schema=None):
-        super(Archive, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None, target=None):
+        super(Archive, self).__init__(name=name, properties=properties)
         self._target = target
 
     @staticmethod
-    def create(properties, own_schema):
+    def create(properties):
         return Archive(name=properties.name,
                        properties=properties,
-                       target=properties.type.archive.name,
-                       own_schema=own_schema)
+                       target=properties.type.archive.name)
 
     @property
     def target(self):

--- a/generator/tree/nodes/resources/base.py
+++ b/generator/tree/nodes/resources/base.py
@@ -4,10 +4,9 @@ from generator.tree.nodes.references import BuiltinStructureReference, Structure
 
 
 class ResourceBase(Node):
-    def __init__(self, name, properties=None, own_schema=None):
+    def __init__(self, name, properties=None,):
         super(ResourceBase, self).__init__(name=name, properties=properties)
         self._decorations = []
-        self._own_schema = own_schema
         if properties is not None and 'decorations' in properties:
             self._decorations = properties.decorations
             for d in self._decorations:

--- a/generator/tree/nodes/resources/bound_resource.py
+++ b/generator/tree/nodes/resources/bound_resource.py
@@ -3,16 +3,15 @@ from generator.tree.nodes.references import ResourceReference
 
 
 class BoundResource(ResourceBase):
-    def __init__(self, name, properties=None, resources=None, own_schema=None):
-        super(BoundResource, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None, resources=None):
+        super(BoundResource, self).__init__(name=name, properties=properties)
         self._resources = resources
 
     @staticmethod
-    def create(properties, own_schema):
+    def create(properties):
         return BoundResource(name=properties.name,
                              properties=properties,
-                             resources=[r for r in properties.resources],
-                             own_schema=own_schema)
+                             resources=[r for r in properties.resources])
 
     def _create_references(self):
         return [ResourceReference(name=r) for r in self._resources]

--- a/generator/tree/nodes/resources/instance.py
+++ b/generator/tree/nodes/resources/instance.py
@@ -3,16 +3,15 @@ from generator.tree.nodes.references import StructureReference
 
 
 class Instance(ResourceBase):
-    def __init__(self, name, properties=None, type=None, own_schema=None):
-        super(Instance, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None, type=None):
+        super(Instance, self).__init__(name=name, properties=properties)
         self._type = type
 
     @staticmethod
-    def create(properties, own_schema):
+    def create(properties):
         return Instance(name=properties.name,
                         properties=properties,
-                        type=properties.type.object.type,
-                        own_schema=own_schema)
+                        type=properties.type.object.type)
 
     def _create_references(self):
         return [StructureReference(name=self._type)]

--- a/generator/tree/nodes/resources/multivector.py
+++ b/generator/tree/nodes/resources/multivector.py
@@ -6,20 +6,19 @@ from generator.tree.nodes.trivial import Structure
 
 
 class Multivector(ResourceBase):
-    def __init__(self, name, properties=None, types=None, width=None, own_schema=None):
-        super(Multivector, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None, types=None, width=None):
+        super(Multivector, self).__init__(name=name, properties=properties)
         self._types = []
         if types is not None:
             self._types = types
         self._width = width
 
     @staticmethod
-    def create(properties, own_schema):
+    def create(properties):
         return Multivector(name=properties.name,
                            properties=properties,
                            types=[t for t in properties.type.multivector.type],
-                           width=int(properties.type.multivector.width),
-                           own_schema=own_schema)
+                           width=int(properties.type.multivector.width))
 
     def _create_references(self):
         return [StructureReference(name=t) for t in self._types]
@@ -48,6 +47,5 @@ class Multivector(ResourceBase):
             schema="struct IndexType%s { value : u64 : %s; }" % (self._width, self._width),
             doc="/** Builtin type to for MultiVector index */",
             fields=[FieldProperties(name="value", width=self._width, type="u64")])
-        index_type = Structure.create(properties=properties, own_schema=properties.schema,
-                                      definition="")
+        index_type = Structure.create(properties=properties, definition="")
         return [index_type]

--- a/generator/tree/nodes/resources/rawdata.py
+++ b/generator/tree/nodes/resources/rawdata.py
@@ -2,12 +2,12 @@ from .base import ResourceBase
 
 
 class RawData(ResourceBase):
-    def __init__(self, name, properties=None, own_schema=None):
-        super(RawData, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None):
+        super(RawData, self).__init__(name=name, properties=properties)
 
     @staticmethod
-    def create(properties, own_schema):
-        return RawData(name=properties.name, properties=properties, own_schema=own_schema)
+    def create(properties):
+        return RawData(name=properties.name, properties=properties)
 
     def _create_references(self):
         return []

--- a/generator/tree/nodes/resources/vector.py
+++ b/generator/tree/nodes/resources/vector.py
@@ -3,16 +3,15 @@ from generator.tree.nodes.references import StructureReference
 
 
 class Vector(ResourceBase):
-    def __init__(self, name, properties=None, type=None, own_schema=None):
-        super(Vector, self).__init__(name=name, properties=properties, own_schema=own_schema)
+    def __init__(self, name, properties=None, type=None):
+        super(Vector, self).__init__(name=name, properties=properties)
         self._type = type
 
     @staticmethod
-    def create(properties, own_schema):
+    def create(properties):
         return Vector(name=properties.name,
                       properties=properties,
-                      type=properties.type.vector.type,
-                      own_schema=own_schema)
+                      type=properties.type.vector.type)
 
     def _create_references(self):
         return [StructureReference(name=self._type)]

--- a/generator/tree/nodes/trivial/constant.py
+++ b/generator/tree/nodes/trivial/constant.py
@@ -3,17 +3,16 @@ from generator.tree.helpers.basictype import BasicType
 from generator.tree.errors import InvalidConstantValueError
 
 class Constant(Node):
-    def __init__(self, name, properties=None, own_schema=None):
+    def __init__(self, name, properties=None):
         super(Constant, self).__init__(name=name, properties=properties)
-        self._own_schema = own_schema
         if properties:
             self._value = int(properties.value, 0)
             if self.type.bits_required(self.value) > self.type.width:
                 raise InvalidConstantValueError(name=name, value=self.value)
 
     @staticmethod
-    def create(properties, own_schema, definition):
-        result = Constant(name=properties.name, properties=properties, own_schema=own_schema)
+    def create(properties, definition):
+        result = Constant(name=properties.name, properties=properties)
         return result
 
     @property

--- a/generator/tree/nodes/trivial/enumeration.py
+++ b/generator/tree/nodes/trivial/enumeration.py
@@ -5,17 +5,16 @@ from .enumeration_value import EnumerationValue
 from generator.tree.helpers.basictype import BasicType
 
 class Enumeration(Node):
-    def __init__(self, name, properties=None, own_schema=None, type=None):
+    def __init__(self, name, properties=None, type=None):
         super(Enumeration, self).__init__(name=name, properties=properties)
-        self._own_schema = own_schema
         self._type=type
 
         if self._type is not None:
             self._type = BasicType(name=self._type)
 
     @staticmethod
-    def create(properties, own_schema, definition):
-        result = Enumeration(name=properties.name, properties=properties, own_schema=own_schema, type=properties.type)
+    def create(properties, definition):
+        result = Enumeration(name=properties.name, properties=properties, type=properties.type)
 
         current_assigned_value = 0
         unique_values = set();

--- a/generator/tree/nodes/trivial/enumeration_value.py
+++ b/generator/tree/nodes/trivial/enumeration_value.py
@@ -1,9 +1,8 @@
 from generator.tree.nodes.node import Node
 
 class EnumerationValue(Node):
-    def __init__(self, name, value, properties=None, own_schema=None):
+    def __init__(self, name, value, properties=None):
         super(EnumerationValue, self).__init__(name=name, properties=properties)
-        self._own_schema = own_schema
         self._value = value
 
     @staticmethod

--- a/generator/tree/nodes/trivial/structure.py
+++ b/generator/tree/nodes/trivial/structure.py
@@ -3,7 +3,7 @@ from .field import Field
 
 
 class Structure(Node):
-    def __init__(self, name, properties=None, own_schema=None):
+    def __init__(self, name, properties=None):
         """
         Use to instantiate empty structure.
         No special properties are evaluated.
@@ -12,11 +12,10 @@ class Structure(Node):
         :param properties: properties. can be missing.
         """
         super(Structure, self).__init__(name=name, properties=properties)
-        self._own_schema = own_schema
 
     @staticmethod
-    def create(properties, own_schema, definition):
-        result = Structure(name=properties.name, properties=properties, own_schema=own_schema)
+    def create(properties, definition):
+        result = Structure(name=properties.name, properties=properties)
 
         for field in properties.fields:
             result.insert(Field.create(properties=field))

--- a/generator/tree/syntax_tree.py
+++ b/generator/tree/syntax_tree.py
@@ -9,7 +9,6 @@ from generator.tree.nodes.resources import ResourceBase, BoundResource
 from generator.tree.nodes.archive import Archive
 from generator.tree.nodes.references import ResourceReference
 
-
 class SyntaxTree(object):
     """
     Flatdata Syntax Tree.
@@ -65,11 +64,12 @@ class SyntaxTree(object):
 
     @staticmethod
     def schema(node):
-        nodes = SyntaxTree.dependent_types(node)
-        nodes.append(node)
-        schemas = ['namespace {path} {{ {schema} }}'.format(path=SyntaxTree.namespace_path(n),
-                                                            schema=n._own_schema) for n in nodes]
-        return '\n'.join(schemas)
+        from ..generators.FlatdataGenerator import FlatdataGenerator
+        generator = FlatdataGenerator()
+
+        # extract subtree from syntax tree
+        subtree = node.extract_subtree()
+        return generator.render(subtree)
 
     @staticmethod
     def namespaces(node):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,10 @@ if(NOT HAS_FLATDATA_PY_PKGS)
 endif()
 
 find_program(NOSETESTS nosetests)
+find_program(PYTHON3_EXECUTABLE python3)
 
 if(NOSETESTS)
-    add_test(NAME flatdata_py_test COMMAND ${NOSETESTS} ${CMAKE_CURRENT_LIST_DIR})
+    add_test(NAME flatdata_py_test COMMAND ${PYTHON3_EXECUTABLE} -m nose ${CMAKE_CURRENT_LIST_DIR})
     set_property(TEST flatdata_py_test PROPERTY
         ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_LIST_DIR}/../flatdata-py")
 else()

--- a/tests/generators/test_cpp_generator.py
+++ b/tests/generators/test_cpp_generator.py
@@ -284,10 +284,14 @@ def test_structures_are_defined_correctly():
 namespace n {
 namespace internal
 {
-    const char* const S__schema__ = R"schema(namespace n { struct S {
+    const char* const S__schema__ = R"schema(namespace n {
+    struct S
+    {
         f0 : u8 : 7;
         f1 : i16 : 13;
-    } })schema";
+    }
+    }
+    )schema";
 }
 
 template< template < typename, int, int > class Member >
@@ -386,6 +390,7 @@ std::string STemplate< Member >::describe( ) const
     ss << "Structure of size " << size_in_bytes( );
     return ss.str( );
 }
+
 } // namespace n
 """)
 
@@ -401,21 +406,41 @@ def test_archives_are_defined_correctly():
     }
     }
     """, CppGenerator, """
-namespace n {
+namespace n { 
 namespace internal
 {
 const char* const A__schema__ =
-"namespace n { struct S {\\n"
-    "        f0 : u8 : 7;\\n"
-    "    } }\\n"
-    "namespace n { archive A {\\n"
-    "        r : S;\\n"
-    "    } }";
+"namespace n {\\n"
+    "struct S\\n"
+    "{\\n"
+    "    f0 : u8 : 7;\\n"
+    "}\\n"
+    "}\\n"
+    "\\n"
+    "namespace n {\\n"
+    "archive A\\n"
+    "{\\n"
+    "    r : .n.S;\\n"
+    "}\\n"
+    "}\\n"
+    "\\n"
+    "";
 const char* const A__r__schema__ =
-"namespace n { struct S {\\n"
-    "        f0 : u8 : 7;\\n"
-    "    } }\\n"
-    "namespace n { r : S; }";
+"namespace n {\\n"
+    "struct S\\n"
+    "{\\n"
+    "    f0 : u8 : 7;\\n"
+    "}\\n"
+    "}\\n"
+    "\\n"
+    "namespace n {\\n"
+    "archive A\\n"
+    "{\\n"
+    "    r : .n.S;\\n"
+    "}\\n"
+    "}\\n"
+    "\\n"
+    "";
 }
 // -------------------------------------------------------------------------------------------------
 
@@ -522,9 +547,10 @@ ABuilder::set_r( RReaderType data )
 {
     check_created( );
     return storage( ).write< RReaderType >( "r", internal::A__r__schema__, data );
-
 }
+
 } // namespace n
+
 """)
 
 

--- a/tests/generators/test_python_generator.py
+++ b/tests/generators/test_python_generator.py
@@ -14,14 +14,16 @@ class foo_S(flatdata.structure.Structure):
     \"\"\"/**
  * This is S
  */\"\"\"
-    _SCHEMA = \"\"\"namespace foo { /**
- * This is S
- */
-struct S {
+    _SCHEMA = \"\"\"namespace foo {
+struct S
+{
     member1 : u8 : 3;
     member2 : u64 : 17;
     member3 : i32 : 11;
-} }\"\"\"
+}
+}
+
+\"\"\"
     _SIZE_IN_BITS = 31
     _SIZE_IN_BYTES = 4
     _FIELDS = {
@@ -50,16 +52,36 @@ def test_archives_are_defined_correctly():
     expectation = [
         """
 class foo_A(flatdata.archive.Archive):
-    _SCHEMA = \"\"\"namespace foo { struct S {
+    _SCHEMA = \"\"\"namespace foo {
+struct S
+{
     f1 : u8 : 3;
-} }
-namespace foo { archive A {
-    r0 : S;
-} }\"\"\"
-    _R0_SCHEMA = \"\"\"namespace foo { struct S {
+}
+}
+
+namespace foo {
+archive A
+{
+    r0 : .foo.S;
+}
+}
+
+\"\"\"
+    _R0_SCHEMA = \"\"\"namespace foo {
+struct S
+{
     f1 : u8 : 3;
-} }
-namespace foo { r0 : S; }\"\"\"
+}
+}
+
+namespace foo {
+archive A
+{
+    r0 : .foo.S;
+}
+}
+
+\"\"\"
     _R0_DOC = \"\"\"\"\"\"
     _NAME = "A"
     _RESOURCES = {
@@ -78,6 +100,7 @@ namespace foo { r0 : S; }\"\"\"
 
     def __init__(self, path):
         flatdata.archive.Archive.__init__(self, path)
+
         """
     ]
     generate_and_assert_in("""

--- a/tests/tree/test_syntax_tree_builder.py
+++ b/tests/tree/test_syntax_tree_builder.py
@@ -234,11 +234,70 @@ def test_all_flatdata_features_look_as_expected_in_fully_built_tree():
     }, tree.symbols(include_types=True))
 
 
-def test_tree_with_all_features_schema_results_in_the_same_tree():
-    expected_tree = SyntaxTreeBuilder.build(TREE_WITH_ALL_FEATURES)
-    schema = expected_tree.schema(expected_tree.find('.ns.A1'))
-    actual_tree = SyntaxTreeBuilder.build(schema)
-    assert_equal(expected_tree.symbols(include_types=True), actual_tree.symbols(include_types=True))
+def test_tree_with_all_features_schema_results_in_the_same_normalized_tree():
+    tree = SyntaxTreeBuilder.build(TREE_WITH_ALL_FEATURES)
+    schema = tree.schema(tree.find('.ns.A1'))
+    generated_tree = SyntaxTreeBuilder.build(schema)
+    assert_equal({
+        '._builtin': Namespace,
+        '._builtin.multivector': Namespace,
+        '._builtin.multivector.IndexType14': Structure,
+        '._builtin.multivector.IndexType14.value': Field,
+        '.ns': Namespace,
+        '.ns.A0': Archive,
+        '.ns.A0.@@ns@C': ConstantReference,
+        '.ns.A0.b': BoundResource,
+        '.ns.A0.b.@@ns@A0@v0': ResourceReference,
+        '.ns.A0.b.@@ns@A0@v1': ResourceReference,
+        '.ns.A0.v0': Vector,
+        '.ns.A0.v0.@@ns@S1': StructureReference,
+        '.ns.A0.v1': Multivector,
+        '.ns.A0.v1.@@_builtin@multivector@IndexType14': BuiltinStructureReference,
+        '.ns.A0.v1.@@ns@S1': StructureReference,
+        '.ns.A1': Archive,
+        '.ns.A1.@@ns@C': ConstantReference,
+        '.ns.A1.a': res.Archive,
+        '.ns.A1.a.@@ns@A0': ArchiveReference,
+        '.ns.A1.i': Instance,
+        '.ns.A1.i.@@ns@S0': StructureReference,
+        '.ns.A1.mv': Multivector,
+        '.ns.A1.mv.@@_builtin@multivector@IndexType14': BuiltinStructureReference,
+        '.ns.A1.mv.@@ns@S0': StructureReference,
+        '.ns.A1.mv.er__ns_S0_f0__ns_A1_v0': ExplicitReference,
+        '.ns.A1.mv.er__ns_S0_f0__ns_A1_v0.@@ns@A1@v0': ResourceReference,
+        '.ns.A1.mv.er__ns_S0_f0__ns_A1_v0.@@ns@S0': StructureReference,
+        '.ns.A1.mv.er__ns_S0_f0__ns_A1_v0.@@ns@S0@f0': FieldReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v0': ExplicitReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v0.@@ns@A1@v0': ResourceReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v0.@@ns@S0': StructureReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v0.@@ns@S0@f1': FieldReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v1': ExplicitReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v1.@@ns@A1@v1': ResourceReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v1.@@ns@S0': StructureReference,
+        '.ns.A1.mv.er__ns_S0_f1__ns_A1_v1.@@ns@S0@f1': FieldReference,
+        '.ns.A1.rd': RawData,
+        '.ns.A1.v0': Vector,
+        '.ns.A1.v0.@@ns@S1': StructureReference,
+        '.ns.A1.v1': Vector,
+        '.ns.A1.v1.@@ns@S1': StructureReference,
+        '.ns.A1.v2': Vector,
+        '.ns.A1.v2.@@ns@XXX': StructureReference,
+        '.ns.C': Constant,
+        '.ns.S0': Structure,
+        '.ns.S0.f0': Field,
+        '.ns.S0.f1': Field,
+        '.ns.S1': Structure,
+        '.ns.S1.f0': Field,
+        '.ns.Enum1': Enumeration,
+        '.ns.Enum1.A': EnumerationValue,
+        '.ns.Enum1.B': EnumerationValue,
+        '.ns.Enum1.C': EnumerationValue,
+        '.ns.XXX': Structure,
+        '.ns.XXX.e': Field,
+        '.ns.XXX.e.@@ns@Enum1': EnumerationReference,
+        '.ns.XXX.f': Field,
+        '.ns.XXX.f.@@ns@Enum1': EnumerationReference,
+    }, generated_tree.symbols(include_types=True))
 
 
 def test_resource_types_are_populated_from_structure_references():


### PR DESCRIPTION
Remove own_schema from tree nodes and use the normalizing Flatdata generator instead

Most of the commit is just adjusting tests/tree, the only real logic is in Node.extract_subtree and SyntaxTree.schema