### PR TITLE
Fix optional in py

### DIFF
--- a/flatdata-py/flatdata/archive.py
+++ b/flatdata-py/flatdata/archive.py
@@ -96,16 +96,15 @@ class Archive(object):
 
     def _open_resource(self, name):
         resource_signature = self._schema_validated_resource_signature(name)
-        if not resource_signature:
-            return None
-
-        resource = resource_signature.container.open(storage=self._resource_storage,
-                                                     name=name,
-                                                     initializer=resource_signature.initializer,
-                                                     is_optional=resource_signature.is_optional)
-        if resource:
-            resource.__doc__ = resource_signature.doc
-            return resource
+        if resource_signature:
+            resource = resource_signature.container.open(storage=self._resource_storage,
+                                                         name=name,
+                                                         initializer=resource_signature.initializer,
+                                                         is_optional=resource_signature.is_optional)
+            if resource:
+                resource.__doc__ = resource_signature.doc
+                return resource
+        return None
 
     @staticmethod
     def _is_archive():

--- a/flatdata-py/flatdata/archive.py
+++ b/flatdata-py/flatdata/archive.py
@@ -107,7 +107,6 @@ class Archive(object):
             resource.__doc__ = resource_signature.doc
             return resource
 
-
     @staticmethod
     def _is_archive():
         """

--- a/flatdata-py/flatdata/archive.py
+++ b/flatdata-py/flatdata/archive.py
@@ -79,23 +79,34 @@ class Archive(object):
         return initializer(nested_storage)
 
     def size_in_bytes(self):
-        return sum( resource_value.size_in_bytes() for resource_value in  ( self.__getattr__(resource)
-            for resource in self._RESOURCES.keys() if resource ) if resource_value )
+        return sum(resource_value.size_in_bytes() for resource_value in
+                   (self.__getattr__(resource) for resource in self._RESOURCES.keys())
+                   if resource_value)
 
     def __len__(self):
         return len(self._RESOURCES)
 
-    def _open_resource(self, name):
+    def _schema_validated_resource_signature(self, name):
         resource_signature = self._RESOURCES[name]
-        if self._check_non_subarchive_schema(name, resource_signature):
-            resource = resource_signature.container.open(storage=self._resource_storage,
-                                                         name=name,
-                                                         initializer=resource_signature.initializer,
-                                                         is_optional=resource_signature.is_optional)
+        storage = self._resource_storage.get(name + _SCHEMA_EXT, resource_signature.is_optional)
+        if storage:
+            self._check_non_subarchive_schema(name, resource_signature, storage)
+            return resource_signature
+        return None
+
+    def _open_resource(self, name):
+        resource_signature = self._schema_validated_resource_signature(name)
+        if not resource_signature:
+            return None
+
+        resource = resource_signature.container.open(storage=self._resource_storage,
+                                                     name=name,
+                                                     initializer=resource_signature.initializer,
+                                                     is_optional=resource_signature.is_optional)
         if resource:
             resource.__doc__ = resource_signature.doc
             return resource
-        return None
+
 
     @staticmethod
     def _is_archive():
@@ -106,16 +117,10 @@ class Archive(object):
         """
         return True
 
-    def _check_non_subarchive_schema(self, name, resource):
+    def _check_non_subarchive_schema(self, name, resource, storage):
         if resource.container._is_archive():
-            return True
-
-        storage = self._resource_storage.get(name + _SCHEMA_EXT, resource.is_optional)
-        if not storage:
-            return False
+            return
 
         actual_schema = storage.read().decode()
         if actual_schema != resource.schema:
             raise SchemaMismatchError(name, resource.schema.splitlines(), actual_schema.splitlines())
-
-        return True


### PR DESCRIPTION
Fixed handling of optional in archive.py.
* guard resource open in case of optional decoration in non sub archive schema
* skip resource values in size_in_bytes() in case of not available optional