### PR TITLE
Fix usage of non-standard GCC compound expressions

### DIFF
--- a/flatdata-cpp/test/ResourceStorageTest.cpp
+++ b/flatdata-cpp/test/ResourceStorageTest.cpp
@@ -8,8 +8,8 @@
 #include <flatdata/flatdata.h>
 #include <gtest/gtest.h>
 
-using test_structures::TestIndexType32;
 using test_structures::AStruct;
+using test_structures::TestIndexType32;
 
 namespace flatdata
 {
@@ -22,12 +22,12 @@ const char* const incorrect_schema = "bar";
 TEST( ResourceStorageTest, schema_is_checked_for_multi_vector )
 {
     std::unique_ptr< ResourceStorage > a = MemoryResourceStorage::create( );
-    EXPECT_NO_THROW( (
-        {
-            auto v = a->create_multi_vector< TestIndexType32, AStruct >( resource_name,
-                                                                         correct_schema );
-            v.close( );
-        } ) );
+    auto create = [&] {
+        auto v
+            = a->create_multi_vector< TestIndexType32, AStruct >( resource_name, correct_schema );
+        v.close( );
+    };
+    EXPECT_NO_THROW( create( ) );
 
     ASSERT_FALSE(
         ( a->read< MultiArrayView< TestIndexType32, AStruct > >( resource_name, incorrect_schema )
@@ -40,11 +40,11 @@ TEST( ResourceStorageTest, schema_is_checked_for_multi_vector )
 TEST( ResourceStorageTest, schema_is_checked_for_external_vector )
 {
     std::unique_ptr< ResourceStorage > a = MemoryResourceStorage::create( );
-    EXPECT_NO_THROW( (
-        {
-            auto v = a->create_external_vector< AStruct >( resource_name, correct_schema );
-            v.close( );
-        } ) );
+    auto create = [&] {
+        auto v = a->create_external_vector< AStruct >( resource_name, correct_schema );
+        v.close( );
+    };
+    EXPECT_NO_THROW( create( ) );
 
     ASSERT_FALSE(
         ( a->read< ArrayView< AStruct > >( resource_name, incorrect_schema ).is_initialized( ) ) );
@@ -55,12 +55,12 @@ TEST( ResourceStorageTest, schema_is_checked_for_external_vector )
 TEST( ResourceStorageTest, schema_is_checked_for_written_structure )
 {
     std::unique_ptr< ResourceStorage > a = MemoryResourceStorage::create( );
-    EXPECT_NO_THROW( (
-        {
-            std::vector< uint8_t > data( AStruct::size_in_bytes( ) );
-            AStruct v( data.data( ) );
-            a->write( resource_name, correct_schema, v );
-        } ) );
+    auto create = [&] {
+        std::vector< uint8_t > data( AStruct::size_in_bytes( ) );
+        AStruct v( data.data( ) );
+        a->write( resource_name, correct_schema, v );
+    };
+    EXPECT_NO_THROW( create( ) );
 
     ASSERT_FALSE( ( a->read< AStruct >( resource_name, incorrect_schema ).is_initialized( ) ) );
     ASSERT_TRUE( ( a->read< AStruct >( resource_name, correct_schema ).is_initialized( ) ) );
@@ -69,11 +69,11 @@ TEST( ResourceStorageTest, schema_is_checked_for_written_structure )
 TEST( ResourceStorageTest, schema_is_checked_for_written_vector )
 {
     std::unique_ptr< ResourceStorage > a = MemoryResourceStorage::create( );
-    EXPECT_NO_THROW( (
-        {
-            Vector< AStruct > v;
-            a->write( resource_name, correct_schema, v );
-        } ) );
+    auto create = [&] {
+        Vector< AStruct > v;
+        a->write( resource_name, correct_schema, v );
+    };
+    EXPECT_NO_THROW( create( ) );
 
     ASSERT_FALSE(
         ( a->read< ArrayView< AStruct > >( resource_name, incorrect_schema ).is_initialized( ) ) );


### PR DESCRIPTION
EXPECT_NO_THROW expects an expression not a scope