### PR TITLE
Make debug output for generator tests more readable

### DIFF
--- a/tests/generators/assertions.py
+++ b/tests/generators/assertions.py
@@ -8,27 +8,19 @@ from nose.tools import *
 from generator.tree.builder import SyntaxTreeBuilder
 import re
 
-
 def unify_whitespace(value):
     removed_trailing = re.sub(r"\s+$", "", value)
     return re.sub(r"\s+", " ", removed_trailing)
 
-
-def assert_in_ignoring_whitespace(member, container):
-    assert_in(unify_whitespace(member), unify_whitespace(container))
-
-
-def assert_not_in_ignoring_whitespace(member, container):
-    assert_not_in(unify_whitespace(member), unify_whitespace(container))
-
-
-def generate_and_assert_in(definition, generator, *expectations, **kwargs):
+def generate_and_assert_in(definition, generator, *expectations, unexpected_items = None):
     tree = SyntaxTreeBuilder.build(definition=definition)
     contents = generator().render(tree)
-    if kwargs.get('debug') == True:
-        print(contents)
+    contents_unified = unify_whitespace(contents)
     for expectation in expectations:
-        assert_in_ignoring_whitespace(expectation, contents)
+        expectation_unified = unify_whitespace(expectation)
+        assert expectation_unified in contents_unified, "\n*Did not find:\n%s\n========== IN GENERATED CODE ===========\n%s" % (expectation, contents)
 
-    for unexpected_item in kwargs.get('unexpected_items', []):
-        assert_not_in_ignoring_whitespace(unexpected_item, contents)
+    if unexpected_items != None:
+        for unexpected_item in unexpected_items:
+            unexpected_item_unified = unify_whitespace(unexpected_item)
+            assert not unexpected_item_unified in contents_unified, "\n*Did find:\n%s\n========== IN GENERATED CODE ===========\n%s" % (unexpected_item, contents)


### PR DESCRIPTION
Whenever generator tests failed it was printing the whitespace-less version of the schema, which make the test hard to maintain. This should switch to print the original generated version on failure.