### PR TITLE
Return ArrayView when closing ExternalVector.

### DIFF
--- a/flatdata-cpp/include/flatdata/ExternalVector.h
+++ b/flatdata-cpp/include/flatdata/ExternalVector.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <boost/noncopyable.hpp>
+#include <boost/optional.hpp>
 
 namespace flatdata
 {
@@ -38,7 +39,7 @@ public:
      */
     ValueType grow( );
 
-    bool close( );
+    boost::optional< ArrayView< T > > close( );
 
 private:
     void flush( );
@@ -65,7 +66,8 @@ ExternalVector< T >::size( ) const
     return m_size;
 }
 
-template< typename T > bool
+template < typename T >
+bool
 ExternalVector< T >::empty( ) const
 {
     return m_size == 0;
@@ -95,11 +97,17 @@ ExternalVector< T >::flush( )
 }
 
 template < typename T >
-bool
+boost::optional< ArrayView< T > >
 ExternalVector< T >::close( )
 {
     flush( );
-    return m_array->close( );
+    boost::optional< MemoryDescriptor > data = m_array->close( );
+    if ( !data )
+    {
+        return boost::none;
+    }
+
+    return ArrayView< T >{data->data( ), data->data( ) + data->size_in_bytes( )};
 }
 
 }  // namespace flatdata

--- a/flatdata-cpp/include/flatdata/ResourceStorage.h
+++ b/flatdata-cpp/include/flatdata/ResourceStorage.h
@@ -7,10 +7,10 @@
 
 #include "ArrayView.h"
 #include "ExternalVector.h"
-#include "internal/Writer.h"
-#include "internal/ResourceStorageCommon.h"
 #include "MemoryDescriptor.h"
 #include "MultiVector.h"
+#include "internal/ResourceStorageCommon.h"
+#include "internal/Writer.h"
 
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
@@ -21,7 +21,6 @@
 namespace flatdata
 {
 class MemoryMappedFileStorage;
-class ResourceHandle;
 
 /**
  * @brief Hierarchical Resource Storage.

--- a/flatdata-cpp/include/flatdata/internal/ResourceHandle.h
+++ b/flatdata-cpp/include/flatdata/internal/ResourceHandle.h
@@ -5,12 +5,15 @@
 
 #pragma once
 
+#include "../MemoryDescriptor.h"
 #include "ResourceStorageCommon.h"
 
 #include <boost/noncopyable.hpp>
+#include <boost/optional.hpp>
 
 #include <exception>
 #include <fstream>
+#include <functional>
 #include <memory>
 
 namespace flatdata
@@ -21,12 +24,15 @@ public:
     ~ResourceHandle( ) noexcept( false );
     template < typename T >
     void write( T* data, size_t size_in_bytes );
-    bool close( );
+    boost::optional< MemoryDescriptor > close( );
 
-    static std::unique_ptr< ResourceHandle > create( std::shared_ptr< std::ostream > stream );
+    static std::unique_ptr< ResourceHandle > create(
+        std::shared_ptr< std::ostream > stream,
+        std::function< boost::optional< MemoryDescriptor >( ) > resource_reader );
 
 private:
     std::shared_ptr< std::ostream > m_stream;
+    std::function< boost::optional< MemoryDescriptor >( ) > m_resource_reader;
     resource_storage::size_type m_size_in_bytes = 0;
 };
 
@@ -50,7 +56,8 @@ ResourceHandle::write( T* data, size_t size_in_bytes )
 }
 
 inline std::unique_ptr< ResourceHandle >
-ResourceHandle::create( std::shared_ptr< std::ostream > stream )
+ResourceHandle::create( std::shared_ptr< std::ostream > stream,
+                        std::function< boost::optional< MemoryDescriptor >( ) > resource_reader )
 {
     std::unique_ptr< ResourceHandle > result( new ResourceHandle( ) );
     result->m_stream = std::move( stream );
@@ -59,16 +66,18 @@ ResourceHandle::create( std::shared_ptr< std::ostream > stream )
         return std::unique_ptr< ResourceHandle >( );
     }
 
+    result->m_resource_reader = std::move( resource_reader );
+
     resource_storage::write_to_stream< resource_storage::size_type >( *result->m_stream, 0 );
     return result;
 }
 
-inline bool
+inline boost::optional< MemoryDescriptor >
 ResourceHandle::close( )
 {
     if ( m_stream == nullptr )
     {
-        return false;
+        return boost::none;
     }
     resource_storage::write_padding( *m_stream );
 
@@ -78,7 +87,12 @@ ResourceHandle::close( )
     m_stream->flush( );
     bool success = static_cast< bool >( *m_stream );
     m_stream.reset( );
-    return success;
+    if ( !success )
+    {
+        return boost::none;
+    }
+
+    return m_resource_reader( );
 }
 
 }  // namespace flatdata

--- a/flatdata-cpp/test/ExternalVectorTest.cpp
+++ b/flatdata-cpp/test/ExternalVectorTest.cpp
@@ -20,11 +20,18 @@ TEST( ExternalVectorTest, FillingData )
     data.grow( ).value = 11;
     data.grow( ).value = 12;
     ASSERT_EQ( size_t( 3 ), data.size( ) );
-    data.close( );
 
-    auto view = *storage->read< ArrayView< AStruct > >( "data", "foo" );
-    ASSERT_EQ( size_t( 3 ), view.size( ) );
-    EXPECT_EQ( uint64_t( 10 ), view[ 0 ].value );
-    EXPECT_EQ( uint64_t( 11 ), view[ 1 ].value );
-    EXPECT_EQ( uint64_t( 12 ), view[ 2 ].value );
+    boost::optional< ArrayView< AStruct > > view_from_close = data.close( );
+    ASSERT_TRUE( view_from_close );
+    ASSERT_EQ( size_t( 3 ), view_from_close->size( ) );
+    EXPECT_EQ( uint64_t( 10 ), ( *view_from_close )[ 0 ].value );
+    EXPECT_EQ( uint64_t( 11 ), ( *view_from_close )[ 1 ].value );
+    EXPECT_EQ( uint64_t( 12 ), ( *view_from_close )[ 2 ].value );
+
+    auto view_from_storage = storage->read< ArrayView< AStruct > >( "data", "foo" );
+    ASSERT_TRUE( view_from_storage );
+    ASSERT_EQ( size_t( 3 ), view_from_storage->size( ) );
+    EXPECT_EQ( uint64_t( 10 ), ( *view_from_storage )[ 0 ].value );
+    EXPECT_EQ( uint64_t( 11 ), ( *view_from_storage )[ 1 ].value );
+    EXPECT_EQ( uint64_t( 12 ), ( *view_from_storage )[ 2 ].value );
 }


### PR DESCRIPTION
Impl. detail: ResourceHandle cannot contain a reference to
ResourceStorage, since this would create a circular dependency:
ResourceStorage -> ExternalVector -> ResourceHandle.

Therefore, we provide a black-box read_resource function to
ResourceHandle, which returns a MemoryDescriptor. The latter
is used by ExternalVector to create the corresponding ArrayView.

Resolves #62.