### PR TITLE
Fix tie-break order of generated entities to match input order...

### DIFF
--- a/flatdata-go/backward-compatibility-tests/test_data.go
+++ b/flatdata-go/backward-compatibility-tests/test_data.go
@@ -86,20 +86,20 @@ func getMultivectorIndexPayload() []byte {
 
 func getMultivectorSchema() string {
 	return `namespace backwardcompatibility {
+struct SimpleStruct
+{
+    a : u32 : 32;
+    b : u32 : 32;
+}
+}
+
+namespace backwardcompatibility {
 struct SignedStruct
 {
     a : i16 : 5;
     b : u32 : 32;
     c : i32 : 7;
     d : u32 : 32;
-}
-}
-
-namespace backwardcompatibility {
-struct SimpleStruct
-{
-    a : u32 : 32;
-    b : u32 : 32;
 }
 }
 

--- a/generator/tree/traversal.py
+++ b/generator/tree/traversal.py
@@ -60,7 +60,7 @@ class DfsTraversal(_Traversal):
                 discovered.add(node)
                 stack.append(State(node=node, processed=True))
 
-                for child in _Traversal.children(node):
+                for child in reversed(_Traversal.children(node)):
                     if child not in discovered and child not in processed:
                         stack.append(State(node=child, processed=False))
                     elif child not in processed:

--- a/generator/tree/traversal.py
+++ b/generator/tree/traversal.py
@@ -30,6 +30,8 @@ class BfsTraversal(_Traversal):
             if node in processed:
                 continue
             yield node, Attr(distance=distance)
+            # We want to preserve original order if possible, and traverse
+            # children in *original* order: That way they are popped in order
             for child in _Traversal.children(node):
                 if child not in processed:
                     queue.append((child, distance + 1))
@@ -60,6 +62,8 @@ class DfsTraversal(_Traversal):
                 discovered.add(node)
                 stack.append(State(node=node, processed=True))
 
+                # We want to preserve original order if possible, and traverse
+                # children in *reverse* order: That way they are popped in order
                 for child in reversed(_Traversal.children(node)):
                     if child not in discovered and child not in processed:
                         stack.append(State(node=child, processed=False))

--- a/tests/generators/test_cpp_generator.py
+++ b/tests/generators/test_cpp_generator.py
@@ -19,20 +19,20 @@ def test_constants_are_declared_correctly():
         }
     """, CppGenerator, """
 namespace n {
-enum : uint16_t
-{
-    // Comment
-    bar = 66
-};
-} // namespace n
-
-namespace n {
 enum : int8_t
 {
     /**
      * There is some documentation about foo.
      */
     foo = 17
+};
+} // namespace n
+
+namespace n {
+enum : uint16_t
+{
+    // Comment
+    bar = 66
 };
 } // namespace n""")
 

--- a/tests/generators/test_flatdata_generator.py
+++ b/tests/generators/test_flatdata_generator.py
@@ -14,30 +14,13 @@ def generate_and_compare(definition, generator, expectation):
     assert_equal.__self__.maxDiff = None
     assert_equal(expectation, contents);
 
-
-def test_normalization():
-    expected_lines = """namespace ns {
-const i32 D = -10;
-}
-
-namespace ns {
+def expected_schema():
+    return """namespace ns {
 const u32 C = 268435455;
 }
 
 namespace ns {
-struct S1
-{
-    f0 : u64 : 64;
-}
-}
-
-namespace ns {
-@bound_implicitly( b : .ns.A0.v0, .ns.A0.v1 )
-archive A0
-{
-    v0 : vector< .ns.S1 >;
-    v1 : multivector< 14, .ns.S1 >;
-}
+const i32 D = -10;
 }
 
 namespace ns {
@@ -45,6 +28,13 @@ struct S0
 {
     f0 : u64 : 64;
     f1 : u64 : 64;
+}
+}
+
+namespace ns {
+struct S1
+{
+    f0 : u64 : 64;
 }
 }
 
@@ -62,6 +52,15 @@ struct XXX
 {
     e : .ns.Enum1 : 16;
     f : .ns.Enum1 : 4;
+}
+}
+
+namespace ns {
+@bound_implicitly( b : .ns.A0.v0, .ns.A0.v1 )
+archive A0
+{
+    v0 : vector< .ns.S1 >;
+    v1 : multivector< 14, .ns.S1 >;
 }
 }
 
@@ -85,7 +84,9 @@ archive A1
 }
 
 """
-    generate_and_compare("""
+
+def input_schema():
+    return """
 namespace ns{
     // Comment A
     struct S0 {
@@ -141,4 +142,10 @@ struct XXX { e : Enum1; f : .ns.Enum1 : 4; }
         a : archive A0;
     }
 } // ns
-""", FlatdataGenerator, expected_lines)
+"""
+
+def test_normalization():
+    generate_and_compare(input_schema(), FlatdataGenerator, expected_schema())
+
+def test_normalization_is_fixed_point():
+    generate_and_compare(expected_schema(), FlatdataGenerator, expected_schema())

--- a/tests/generators/test_go_generator.py
+++ b/tests/generators/test_go_generator.py
@@ -38,8 +38,8 @@ const (
 def test_constants_are_declared_correctly():
     generate_and_assert_in("""
         namespace n{
-        const i8 foo = 17;
         const u16 bar = 0x42;
+        const i8 foo = 17;
         }
     """, GoGenerator, """
     Bar uint16 = 66

--- a/tests/tree/test_schema_resolution.py
+++ b/tests/tree/test_schema_resolution.py
@@ -59,16 +59,16 @@ archive A
 """)
     assert_equal(SyntaxTree.schema(root.find(".n.A.c")),
                  """namespace n {
-struct V
+struct U
 {
-    v : u8 : 7;
+    u : u8 : 7;
 }
 }
 
 namespace n {
-struct U
+struct V
 {
-    u : u8 : 7;
+    v : u8 : 7;
 }
 }
 
@@ -159,14 +159,14 @@ archive A {
         """)
     resolve_references(root)
     expected = """namespace foo {
-const u8 C = 42;
-}
-
-namespace foo {
 struct T
 {
     f : u8 : 7;
 }
+}
+
+namespace foo {
+const u8 C = 42;
 }
 
 namespace foo {

--- a/tests/tree/test_syntax_tree.py
+++ b/tests/tree/test_syntax_tree.py
@@ -77,23 +77,23 @@ def test_bfs_traversal_basic_ordering():
 def test_dfs_traversal_basic_ordering():
     _check_traversal_order(create_basic_tree(), DfsTraversal, [
         "a",
+        "a.b",
+        "a.b.c",
+        "a.b.d",
+        "a.b.e",
         "a.f",
         "a.f.g",
-        "a.f.g.h",
-        "a.b",
-        "a.b.e",
-        "a.b.d",
-        "a.b.c"
+        "a.f.g.h"
     ])
 
 
 def test_dfs_traversal_expands_type_references():
     _check_traversal_order(create_tree_with_type_refs(), DfsTraversal, [
         "a",
-        "a.c",
+        "a.b",
         "a.b.d",
         "a.c.e",
-        "a.b"
+        "a.c"
     ])
 
 
@@ -116,10 +116,10 @@ def test_dfs_traversal_reports_cyclic_references():
 def test_dfs_traversal_provides_topological_ordering():
     assert_equal(
         [
-            "ns.A1",
             "ns.S0",
-            "ns.A0.R1",
+            "ns.A1",
             "ns.A0.R0",
+            "ns.A0.R1",
             "ns.A0",
             "ns"
         ],


### PR DESCRIPTION

... not reverse input order: The topological sort was going through children in reverse order. This caused the normalized schema to change when re-normalized.