### PR TITLE
Fix a race condition when closing resources.

### DIFF
--- a/flatdata-cpp/include/flatdata/FileResourceStorage.h
+++ b/flatdata-cpp/include/flatdata/FileResourceStorage.h
@@ -11,6 +11,7 @@
 #include <boost/filesystem.hpp>
 
 #include <fstream>
+#include <mutex>
 
 namespace flatdata
 {
@@ -53,6 +54,7 @@ private:
 
 private:
     std::unique_ptr< MemoryMappedFileStorage > m_storage;
+    std::mutex m_storage_mutex;
     std::string m_path;
 };
 
@@ -124,6 +126,7 @@ FileResourceStorage::read_resource( const char* key )
     {
         return MemoryDescriptor( );
     }
+    std::lock_guard<std::mutex> lock(m_storage_mutex);
     return m_storage->read( get_path( key ).c_str( ) );
 }
 

--- a/flatdata-cpp/include/flatdata/FileResourceStorage.h
+++ b/flatdata-cpp/include/flatdata/FileResourceStorage.h
@@ -126,7 +126,7 @@ FileResourceStorage::read_resource( const char* key )
     {
         return MemoryDescriptor( );
     }
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     return m_storage->read( get_path( key ).c_str( ) );
 }
 

--- a/flatdata-cpp/include/flatdata/MemoryResourceStorage.h
+++ b/flatdata-cpp/include/flatdata/MemoryResourceStorage.h
@@ -70,7 +70,7 @@ MemoryResourceStorage::create_output_stream( const char* key )
     std::shared_ptr< std::stringstream > result(
         new std::stringstream( std::ofstream::out | std::ofstream::binary ) );
 
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     m_storage->streams[ get_path( key ) ] = result;
 
     return result;
@@ -95,7 +95,7 @@ MemoryResourceStorage::read_resource( const char* key )
 {
     const auto path = get_path( key );
 
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     if ( m_storage->resources.count( path ) == 0 )
     {
         auto found = m_storage->streams.find( path );
@@ -114,7 +114,7 @@ MemoryResourceStorage::read_resource( const char* key )
 inline void
 MemoryResourceStorage::assign_value( const char* key, MemoryDescriptor value )
 {
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     m_storage->resources.insert( std::make_pair(
         std::string( key ),
         std::make_shared< std::string >( value.char_ptr( ), value.size_in_bytes( ) ) ) );
@@ -123,7 +123,7 @@ MemoryResourceStorage::assign_value( const char* key, MemoryDescriptor value )
 inline void
 MemoryResourceStorage::assign_value( const char* key, const char* value )
 {
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     m_storage->resources.insert(
         std::make_pair( std::string( key ), std::make_shared< std::string >( value ) ) );
 }
@@ -132,7 +132,7 @@ inline std::unique_ptr< ResourceStorage >
 MemoryResourceStorage::create_directory( const char* key )
 {
     const auto new_path = get_path( key ) + "/";
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     m_storage->created_directories.insert( new_path );
     return std::unique_ptr< MemoryResourceStorage >(
         new MemoryResourceStorage( m_storage, new_path ) );
@@ -142,7 +142,7 @@ inline std::unique_ptr< ResourceStorage >
 MemoryResourceStorage::directory( const char* key )
 {
     const auto new_path = get_path( key ) + "/";
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     if ( m_storage->created_directories.find( new_path ) == m_storage->created_directories.end( ) )
     {
         return nullptr;
@@ -219,7 +219,7 @@ inline bool
 MemoryResourceStorage::exists( const char* key )
 {
     auto path = get_path( key );
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     return m_storage->resources.count( path ) != 0 || m_storage->streams.count( path ) != 0
            || helpers::prefix_exists( m_storage->resources, path + "/" )
            || helpers::prefix_exists( m_storage->streams, path + "/" );
@@ -234,7 +234,7 @@ MemoryResourceStorage::dump_resources( bool dump_schemas, ResourceSerializer&& f
     };
 
     std::ostringstream ss;
-    std::lock_guard<std::mutex> lock(m_storage_mutex);
+    std::lock_guard< std::mutex > lock( m_storage_mutex );
     for ( auto& resource : m_storage->resources )
     {
         if ( !is_schema( resource.first ) || dump_schemas )

--- a/flatdata-cpp/test/ExternalVectorTest.cpp
+++ b/flatdata-cpp/test/ExternalVectorTest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 
+#include <condition_variable>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -55,6 +56,7 @@ public:
         : m_count{count}
     {
     }
+
     void
     wait( )
     {
@@ -76,11 +78,8 @@ run_close_in_loop( std::unique_ptr< ResourceStorage > storage )
 {
     for ( size_t i = 0; i < 1000; ++i )
     {
-        auto storage = MemoryResourceStorage::create( );
-
         constexpr size_t NUM_THREADS = 4;
         std::vector< std::thread > threads;
-        uint32_t thread_id = 0;
         Barrier barrier( NUM_THREADS );
         for ( uint32_t thread_id = 0; thread_id < NUM_THREADS; ++thread_id )
         {

--- a/flatdata-cpp/test/ExternalVectorTest.cpp
+++ b/flatdata-cpp/test/ExternalVectorTest.cpp
@@ -7,6 +7,11 @@
 
 #include <flatdata/flatdata.h>
 #include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+
+#include <mutex>
+#include <thread>
+#include <vector>
 
 using namespace flatdata;
 using namespace test_structures;
@@ -34,4 +39,79 @@ TEST( ExternalVectorTest, FillingData )
     EXPECT_EQ( uint64_t( 10 ), ( *view_from_storage )[ 0 ].value );
     EXPECT_EQ( uint64_t( 11 ), ( *view_from_storage )[ 1 ].value );
     EXPECT_EQ( uint64_t( 12 ), ( *view_from_storage )[ 2 ].value );
+}
+
+namespace
+{
+class Barrier
+{
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    size_t m_count;
+
+public:
+    explicit Barrier( size_t count )
+        : m_count{count}
+    {
+    }
+    void
+    wait( )
+    {
+        std::unique_lock< std::mutex > lock{m_mutex};
+        m_count -= 1;
+        if ( m_count == 0 )
+        {
+            m_cv.notify_all( );
+        }
+        else
+        {
+            m_cv.wait( lock, [this] { return m_count == 0; } );
+        }
+    }
+};
+
+void
+run_close_in_loop( std::unique_ptr< ResourceStorage > storage )
+{
+    for ( size_t i = 0; i < 1000; ++i )
+    {
+        auto storage = MemoryResourceStorage::create( );
+
+        constexpr size_t NUM_THREADS = 4;
+        std::vector< std::thread > threads;
+        uint32_t thread_id = 0;
+        Barrier barrier( NUM_THREADS );
+        for ( uint32_t thread_id = 0; thread_id < NUM_THREADS; ++thread_id )
+        {
+            threads.emplace_back( [&storage, thread_id, &barrier] {
+                std::string resource_name = "data_" + std::to_string( thread_id );
+                auto data
+                    = storage->create_external_vector< AStruct >( resource_name.c_str( ), "foo" );
+                data.grow( ).value = 10;
+                data.grow( ).value = 11;
+                data.grow( ).value = 12;
+                barrier.wait( );
+                data.close( );
+            } );
+        }
+        for ( uint32_t thread_id = 0; thread_id < NUM_THREADS; ++thread_id )
+        {
+            threads[ thread_id ].join( );
+        }
+    }
+}
+}  // namespace
+
+TEST( ExternalVectorTest, CloseIsThreadSafeForMemoryResourceStorage )
+{
+    run_close_in_loop( MemoryResourceStorage::create( ) );
+}
+
+TEST( ExternalVectorTest, CloseIsThreadSafeForFileResourceStorage )
+{
+    auto tmpdir = boost::filesystem::temp_directory_path( ) / boost::filesystem::unique_path( );
+    boost::filesystem::create_directory( tmpdir );
+    run_close_in_loop( FileResourceStorage::create( tmpdir.c_str( ) ) );
+    boost::filesystem::remove_all( tmpdir );
 }


### PR DESCRIPTION
The race was introduced by reading a resource when closing it for creating a view. The fix makes access to a storage thread-safe.