### PR TITLE
Fix ArrayView::slice_after, add tests and mroe convinience functions

### DIFF
--- a/flatdata-cpp/include/flatdata/ArrayView.h
+++ b/flatdata-cpp/include/flatdata/ArrayView.h
@@ -29,9 +29,15 @@ public:
     const_iterator end( ) const;
     ConstStreamType data( ) const;
 
+    ConstValueType front( ) const;
+    ConstValueType back( ) const;
+
     ArrayView slice( size_t pos, size_t length ) const;
     ArrayView slice_before( size_t pos ) const;
     ArrayView slice_after( size_t pos ) const;
+
+    ArrayView skip( size_t count ) const;
+    ArrayView skip_last( size_t count ) const;
 
     explicit operator bool( ) const;
 

--- a/flatdata-cpp/include/flatdata/internal/ArrayView.inl
+++ b/flatdata-cpp/include/flatdata/internal/ArrayView.inl
@@ -7,7 +7,6 @@
 
 namespace flatdata
 {
-
 template < typename T >
 ArrayView< T >::ArrayView( ConstStreamType data_begin, ConstStreamType data_end )
     : m_data( data_begin )
@@ -19,6 +18,20 @@ template < typename T >
 typename ArrayView< T >::ConstValueType ArrayView< T >::operator[]( size_t i ) const
 {
     return ConstValueType{m_data + T::size_in_bytes( ) * i};
+}
+
+template < typename T >
+typename ArrayView< T >::ConstValueType
+ArrayView< T >::front( ) const
+{
+    return ( *this )[ 0 ];
+}
+
+template < typename T >
+typename ArrayView< T >::ConstValueType
+ArrayView< T >::back( ) const
+{
+    return ( *this )[ size( ) - 1 ];
 }
 
 template < typename T >
@@ -69,11 +82,25 @@ ArrayView< T >
 ArrayView< T >::slice_after( size_t pos ) const
 {
     return ArrayView( m_data + pos * T::size_in_bytes( ),
-                      m_data + ( m_size - pos ) * T::size_in_bytes( ) );
+                      m_data + m_size * T::size_in_bytes( ) );
 }
 
-template< typename T >
-ArrayView< T >::operator bool() const
+template < typename T >
+ArrayView< T >
+ArrayView< T >::skip( size_t count ) const
+{
+    return slice_after( count );
+}
+
+template < typename T >
+ArrayView< T >
+ArrayView< T >::skip_last( size_t count ) const
+{
+    return slice_before( size( ) - count );
+}
+
+template < typename T >
+ArrayView< T >::operator bool( ) const
 {
     return m_data != nullptr;
 }
@@ -93,7 +120,8 @@ ArrayView< T >::end( ) const
 }
 
 template < typename T >
-std::string ArrayView< T >::describe( ) const
+std::string
+ArrayView< T >::describe( ) const
 {
     std::ostringstream ss;
     ss << "Array of size: " << size( ) << " in " << size_in_bytes( ) << " bytes";

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -11,6 +11,22 @@
 using namespace flatdata;
 using namespace test_structures;
 
+TEST( VectorTest, reading )
+{
+    Vector< AStruct > data( 10 );
+    for ( size_t i = 0; i < 10; i++ )
+    {
+        data[ i ].value = i;
+    }
+
+    ArrayView< AStruct > view = data;
+    for ( size_t i = 0; i < 10; i++ )
+    {
+        ASSERT_EQ( i , data[ i ].value );
+    }
+}
+
+
 TEST( VectorTest, slicing )
 {
     Vector< AStruct > data( 10 );

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017 HERE Europe B.V.
+ * See the LICENSE file in the root of this project for license details.
+ */
+
+#include "test_structures.hpp"
+
+#include <flatdata/flatdata.h>
+#include <gtest/gtest.h>
+
+using namespace flatdata;
+using namespace test_structures;
+
+TEST( VectorTest, slicing )
+{
+    Vector< AStruct > data( 10 );
+    for ( size_t i = 0; i < 10; i++ )
+    {
+        data[ i ].value = i;
+    }
+
+    ArrayView< AStruct > view = data;
+    ASSERT_TRUE( view.size( ) == 10 );
+    ASSERT_EQ( 8, view.slice_after( 2 ).size( ) );
+    ASSERT_EQ( 2, view.slice_after( 2 ).front( ).value );
+    ASSERT_EQ( 8, view.skip( 2 ).size( ) );
+    ASSERT_EQ( 2, view.skip( 2 ).front( ).value );
+    ASSERT_EQ( 8, view.skip_last( 2 ).size( ) );
+    ASSERT_EQ( 0, view.skip_last( 2 ).front( ).value );
+    ASSERT_EQ( 8, view.slice_before( 8 ).size( ) );
+    ASSERT_EQ( 0, view.slice_before( 8 ).front( ).value );
+    ASSERT_EQ( 6, view.slice( 2, 6 ).size( ) );
+    ASSERT_EQ( 2, view.slice( 2, 6 ).front( ).value );
+}

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 HERE Europe B.V.
+ * Copyright (c) 2018 HERE Europe B.V.
  * See the LICENSE file in the root of this project for license details.
  */
 


### PR DESCRIPTION
```slice_after( x )``` was actually shortening the length by ``` 2 * x ```

Also added skip (synonym for slice_after), and skip_last (useful for skipping sentinels), as well as front/back.