### PR TITLE
Hide internal symbols from MultiVector/ArrayView API

### DIFF
--- a/flatdata-py/generator/templates/rust/archive.jinja2
+++ b/flatdata-py/generator/templates/rust/archive.jinja2
@@ -7,7 +7,7 @@
 
 /// Builtin union type of {% for type in r.referenced_structures | structure_references %}{{ type.node.path }}{%- if not loop.last %}, {% endif %}{% endfor %}.
 define_variadic_struct!({{ r.name | snake_to_upper_camel_case }}, Ref{{ r.name | snake_to_upper_camel_case }}, Builder{{ r.name | snake_to_upper_camel_case }},
-    {{ r.index_reference.node.name }},
+    {{ fully_qualified_name(archive, r.index_reference.node) }},
 {% for type in r.referenced_structures | structure_references %}
     {{ loop.index0 }} => ( {{type.node.name }}, {{ fully_qualified_name(archive, type.node) }}, add_{{ type.node.name | camel_to_snake_case }})
     {%- if not loop.last %},

--- a/flatdata-py/generator/tests/generators/rust_expectations/archives/multivector.rs
+++ b/flatdata-py/generator/tests/generators/rust_expectations/archives/multivector.rs
@@ -16,19 +16,19 @@ define_struct!(
 
 /// Builtin union type of .n.S, .n.T.
 define_variadic_struct!(Data, RefData, BuilderData,
-    IndexType8,
+    super::_builtin::multivector::IndexType8,
     0 => ( S, super::n::S, add_s),
     1 => ( T, super::n::T, add_t));
 
 /// Builtin union type of .n.S, .n.T.
 define_variadic_struct!(OptionalData, RefOptionalData, BuilderOptionalData,
-    IndexType16,
+    super::_builtin::multivector::IndexType16,
     0 => ( S, super::n::S, add_s),
     1 => ( T, super::n::T, add_t));
 
 /// Builtin union type of .n.S, .n.T.
 define_variadic_struct!(DataU64Index, RefDataU64Index, BuilderDataU64Index,
-    IndexType64,
+    super::_builtin::multivector::IndexType64,
     0 => ( S, super::n::S, add_s),
     1 => ( T, super::n::T, add_t));
 

--- a/flatdata-py/generator/tests/generators/rust_expectations/archives/namespaces.rs
+++ b/flatdata-py/generator/tests/generators/rust_expectations/archives/namespaces.rs
@@ -214,7 +214,7 @@ archive A
 
 /// Builtin union type of .n.S.
 define_variadic_struct!(Multi, RefMulti, BuilderMulti,
-    IndexType32,
+    super::_builtin::multivector::IndexType32,
     0 => ( S, super::n::S, add_s));
 
 define_archive!(A, ABuilder,

--- a/flatdata-rs/lib/src/archive.rs
+++ b/flatdata-rs/lib/src/archive.rs
@@ -123,6 +123,9 @@ pub trait VariadicRef: Clone + Debug + PartialEq {
 /// structs since that binds lifetime too early. Instead this generic factory
 /// and Higher-Rank-Trait-Bounds are used to emulate higher-kinded-generics.
 pub trait VariadicStruct<'a>: Clone {
+    /// Index type
+    type Index: IndexRefFactory;
+
     /// Reader type
     type Item: VariadicRef;
 
@@ -410,6 +413,8 @@ macro_rules! define_variadic_struct {
         pub struct $factory{}
 
         impl<'a> $crate::VariadicStruct<'a> for $factory {
+            type Index = $index_type;
+
             type Item = $name<'a>;
 
             #[inline]
@@ -548,7 +553,7 @@ macro_rules! define_archive {
             })*
 
             $(pub fn $multivector_resource(&self) -> opt!(
-                $crate::MultiArrayView<$index_type, $variadic_type>, $is_optional_multivector)
+                $crate::MultiArrayView<$variadic_type>, $is_optional_multivector)
             {
                 static_if!($is_optional_multivector, {
                     let index_mem_desc = &self.$multivector_resource.0.as_ref();
@@ -726,7 +731,7 @@ macro_rules! define_archive {
             $(pub fn $multivector_start(
                 &self,
             ) -> ::std::io::Result<
-                $crate::MultiVector<$index_type, $variadic_type>
+                $crate::MultiVector<$variadic_type>
             > {
                 $crate::create_multi_vector(
                     &*self.storage,

--- a/flatdata-rs/lib/src/storage.rs
+++ b/flatdata-rs/lib/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::archive::{ArchiveBuilder, IndexStruct, Struct, VariadicStruct};
+use crate::archive::{ArchiveBuilder, Struct, VariadicRefFactory};
 use crate::error::ResourceStorageError;
 use crate::memory::{SizeType, PADDING_SIZE};
 use crate::multivector::MultiVector;
@@ -162,14 +162,13 @@ where
 /// an [`MultiVector`] using this resource for writing and flushing data to
 /// storage.
 #[doc(hidden)]
-pub fn create_multi_vector<'a, Idx, Ts>(
+pub fn create_multi_vector<'a, Ts>(
     storage: &'a ResourceStorage,
     resource_name: &str,
     schema: &str,
-) -> io::Result<MultiVector<'a, Idx, Ts>>
+) -> io::Result<MultiVector<'a, Ts>>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Ts: VariadicRefFactory,
 {
     // create index
     let index_name = format!("{}_index", resource_name);


### PR DESCRIPTION
Previously:
```MultiVector<osmflat::_builtin::multivector::IndexType40, osmflat::RelationMembers>```
Now:
```MultiVector<osmflat::RelationMembers>```