### PR TITLE
Use flatdata-generator when installed in build.rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+dist: bionic
+language: minimal
 
 matrix:
   allow_failures:
@@ -7,36 +9,35 @@ matrix:
   include:
     # flatdata-generator
     - language: python
-      name: "flatdata-generator"
-      dist: xenial
-      python: 3.5
-      script:
+      python: 3.6
+      install:
         - cd flatdata-generator
-        - pip3 install -r requirements.txt  # runtime requirements
-        - pip3 install nose pylint  # CI requirements
-        - python3 -m nose
+        - pip install -r requirements.txt # runtime requirements
+        - pip install nose pylint # CI requirements
+      script:
+        # run tests
+        - python -m nose
         # try to install
-        - pip3 install .
+        - pip install .
         - flatdata-generator --help
 
     # flatdata-py
     - language: python
       name: "flatdata-py"
-      dist: xenial
-      python: 3.5
-      script:
-        - pip3 install ./flatdata-generator
+      python: 3.6
+      install:
+        - pip install ./flatdata-generator
         - cd flatdata-py
-        - pip3 install -r requirements.txt  # runtime requirements
-        - pip3 install nose pylint  # CI requirements
-        - python3 -m nose
-        # try to install
-        - pip3 install .
+        - pip install -r requirements.txt # runtime requirements
+        - pip install nose pylint # CI requirements
+      script:
+        - python -m nose
+        - pip install .
         - flatdata-inspector --help
 
     # cpp
     - language: cpp
-      dist: xenial
+      name: "flatdata-cpp"
       compiler: gcc
       addons:
         apt:
@@ -44,14 +45,14 @@ matrix:
             - python3-pip
             - python3-setuptools
             - libboost-filesystem-dev
-      before_script:
+      install:
         - pip3 install ./flatdata-generator
       script:
         - flatdata-cpp/ci/build-and-test-cpp.sh
 
     # cpp
     - language: cpp
-      dist: xenial
+      name: "flatdata-cpp"
       compiler: clang
       addons:
         apt:
@@ -59,13 +60,14 @@ matrix:
             - python3-pip
             - python3-setuptools
             - libboost-filesystem-dev
-      before_script:
+      install:
         - pip3 install ./flatdata-generator
       script:
         - flatdata-cpp/ci/build-and-test-cpp.sh
 
     # go
     - language: go
+      name: "flatdata-go"
       go: 1.x
       install: true
       before_script:
@@ -82,33 +84,30 @@ matrix:
           pushd flatdata-go/backward-compatibility-tests; make run-ci; popd
 
     # dot
-    - dist: xenial
+    - language: python
+      name: "flatdata-dot"
       addons:
         apt:
           packages:
-            - python3-pip
-            - python3-setuptools
             - graphviz
-      before_script:
+      install:
         - pip3 install ./flatdata-generator
       script:
         - ci/dot_test_cases.sh
 
     # rust
     - language: rust
-      dist: xenial
+      name: "flatdata-rs"
       rust: stable
       cache:
         - cargo
       addons:
         apt:
           packages:
-            - python3-pip
-            - python3-setuptools
-      before_script:
-        - pip3 install ./flatdata-generator
-        - cd flatdata-rs
+            - python3-venv
       script:
+        - export FLATDATA_GENERATOR_PATH=${PWD}/flatdata-generator # use generator from source
+        - cd flatdata-rs
         - cargo build
         - cargo test
       after_success:
@@ -116,36 +115,34 @@ matrix:
 
     # rust
     - language: rust
-      dist: xenial
+      name: "flatdata-rs"
+      dist: bionic
       rust: beta
       cache:
         - cargo
       addons:
         apt:
           packages:
-            - python3-pip
-            - python3-setuptools
-      before_script:
-        - pip3 install ./flatdata-generator
-        - cd flatdata-rs
+            - python3-venv
       script:
+        - export FLATDATA_GENERATOR_PATH=${PWD}/flatdata-generator # use generator from source
+        - cd flatdata-rs
         - cargo build
         - cargo test
 
     # rust
     - language: rust
-      dist: xenial
+      name: "flatdata-rs"
+      dist: bionic
       rust: nightly
       cache:
         - cargo
       addons:
         apt:
           packages:
-            - python3-pip
-            - python3-setuptools
-      before_script:
-        - pip3 install ./flatdata-generator
-        - cd flatdata-rs
+            - python3-venv
       script:
+        - export FLATDATA_GENERATOR_PATH=${PWD}/flatdata-generator # use generator from source
+        - cd flatdata-rs
         - cargo build
         - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: minimal
 
 matrix:
   allow_failures:
+    - rust: beta # see: https://github.com/rust-lang/rust/issues/63888
     - rust: nightly
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   include:
     # flatdata-generator
     - language: python
+      name: "flatdata-generator"
       python: 3.6
       install:
         - cd flatdata-generator

--- a/flatdata-generator/setup.py
+++ b/flatdata-generator/setup.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
+import os
 from setuptools import find_packages, setup
+
+SOURCE_FILEPATH = os.path.dirname(os.path.abspath(__file__))
 
 setup(
     name="flatdata-generator",
     version="0.3.0-2",
     author="Flatdata Developers",
     description="Generate source code for C++, Rust, Go or Python from a Flatdata schema file",
-    long_description=open("README.md").read(),
+    long_description=open(os.path.join(SOURCE_FILEPATH, "README.md")).read(),
     long_description_content_type="text/markdown",
     url="https://github.com/heremaps/flatdata",
     # we can't use find_namespace_packages as it is only a very recent addition to setuptools
-    packages=['flatdata.' + p for p in find_packages('flatdata')],
+    packages=["flatdata." + p for p in find_packages("flatdata")],
     package_data={
-        '': ['*.jinja2'],
+        "": ["*.jinja2"],
     },
     entry_points={
-        'console_scripts': ['flatdata-generator=flatdata.generator.app:main'],
+        "console_scripts": ["flatdata-generator=flatdata.generator.app:main"],
     },
+    setup_requires=["wheel"],
     install_requires=[
         "pyparsing>=2.0",
         "jinja2>=2.2",

--- a/flatdata-py/setup.py
+++ b/flatdata-py/setup.py
@@ -1,26 +1,33 @@
 #!/usr/bin/env python3
+import os
 from setuptools import find_packages, setup
 
+SOURCE_FILEPATH = os.path.dirname(os.path.abspath(__file__))
 
 setup(
     name="flatdata-py",
     version="0.3.0",
     author="Flatdata Developers",
     description="Python 3 implementation of Flatdata",
-    long_description=open("README.md").read(),
+    long_description=open(os.path.join(SOURCE_FILEPATH, "README.md")).read(),
     long_description_content_type="text/markdown",
     url="https://github.com/heremaps/flatdata",
     # we can't use find_namespace_packages as it is only a very recent addition to setuptools
-    packages=['flatdata.' + p for p in find_packages('flatdata')],
+    packages=["flatdata." + p for p in find_packages("flatdata")],
     extras_require={
-        'inspector': ['IPython']
+        "inspector": ["IPython"]
     },
     entry_points={
-        'console_scripts': [
-            'flatdata-inspector = flatdata.lib.inspector:main [inspector]'
+        "console_scripts": [
+            "flatdata-inspector = flatdata.lib.inspector:main [inspector]"
         ],
     },
-    install_requires=open("requirements.txt").readlines(),
+    setup_requires=["wheel"],
+    install_requires=[
+        "flatdata-generator"
+        "numpy",
+        "pandas"
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/flatdata-py/setup.py
+++ b/flatdata-py/setup.py
@@ -24,7 +24,7 @@ setup(
     },
     setup_requires=["wheel"],
     install_requires=[
-        "flatdata-generator"
+        "flatdata-generator",
         "numpy",
         "pandas"
     ],

--- a/flatdata-rs/README.md
+++ b/flatdata-rs/README.md
@@ -18,6 +18,26 @@ the data was de/serialized correctly. Run them simply with:
 cargo test
 ```
 
+## Getting started
+
+We recommend that you use a `build.rs` to automatically generate the code from your `flatdata` schema.
+
+```rust
+fn main() {
+    flatdata::generate("path/to/my_schema.flatdata").unwrap();
+}
+```
+
+```rust
+#![allow(dead_code)]
+include!(concat!(env!("OUT_DIR"), "path/to/my_schema.rs"));
+///
+// re-export if desired
+pub use my_schema::*;
+```
+
+See the [documentation of generator.rs](lib/generator.rs) for a more detailed explaination.
+
 [travis]: https://travis-ci.org/heremaps/flatdata-rs
 [travis status]: https://travis-ci.org/heremaps/flatdata-rs.svg?branch=master
 [latest version]: https://img.shields.io/crates/v/flatdata.svg

--- a/flatdata-rs/lib/src/generator.rs
+++ b/flatdata-rs/lib/src/generator.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::Path, path::PathBuf, process::Command};
 
 /// A helper function wrapping the flatdata generator.
 ///
@@ -31,8 +31,10 @@ use std::{env, path::PathBuf, process::Command};
 ///
 /// `build.rs`
 /// ``` ignore
+/// use std::env;
+///
 /// fn main() {
-///     flatdata::generate("schemas_path/", env!("OUT_DIR")).unwrap();
+///     flatdata::generate("schemas_path/", &env::var("OUT_DIR").unwrap()).unwrap();
 /// }
 /// ```
 ///
@@ -51,16 +53,19 @@ use std::{env, path::PathBuf, process::Command};
 /// picks up the source by setting `FLATDATA_GENERATOR_PATH` to point to the
 /// `flatdata-generator` folder.
 /// ```
-pub fn generate(schemas_path: &str) -> Result<(), GeneratorError> {
-    let schemas_path = PathBuf::from(schemas_path).canonicalize()?;
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("not running in a build.rs script?"));
+pub fn generate<P>(schemas_path: P, out_dir: P) -> Result<(), GeneratorError>
+where
+    P: AsRef<Path>,
+{
+    let schemas_path = schemas_path.as_ref();
+    let out_dir = out_dir.as_ref();
 
     // create a virtualenv in the target folder
     eprintln!("creating python virtualenv");
     let _ = Command::new("python3")
         .arg("-m")
         .arg("venv")
-        .arg(&out_dir)
+        .arg(out_dir)
         .spawn()
         .map_err(GeneratorError::PythonError)?
         .wait()?;

--- a/flatdata-rs/tests/coappearances/build.rs
+++ b/flatdata-rs/tests/coappearances/build.rs
@@ -1,15 +1,3 @@
-use std::path::PathBuf;
-
 fn main() {
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let test_cases_path = PathBuf::from("../../../examples/coappearances/coappearances.flatdata");
-    let generator_path = PathBuf::from("../../../generator");
-
-    match flatdata::generate(&out_path, &test_cases_path, &generator_path) {
-        Err(e) => {
-            eprintln!("{}", e);
-            std::process::exit(1);
-        }
-        _ => (),
-    }
+    flatdata::generate("../../../examples/coappearances/coappearances.flatdata").unwrap();
 }

--- a/flatdata-rs/tests/coappearances/build.rs
+++ b/flatdata-rs/tests/coappearances/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 fn main() {
-    flatdata::generate("../../../examples/coappearances/coappearances.flatdata").unwrap();
+    flatdata::generate("../../../examples/coappearances/coappearances.flatdata", &env::var("OUT_DIR").unwrap()).unwrap();
 }

--- a/flatdata-rs/tests/features/build.rs
+++ b/flatdata-rs/tests/features/build.rs
@@ -1,15 +1,3 @@
-use std::path::PathBuf;
-
 fn main() {
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let test_cases_path = PathBuf::from("../../../test_cases");
-    let generator_path = PathBuf::from("../../../generator");
-
-    match flatdata::generate(&out_path, &test_cases_path, &generator_path) {
-        Err(e) => {
-            eprintln!("{}", e);
-            std::process::exit(1);
-        }
-        _ => (),
-    }
+    flatdata::generate("../../../test_cases").unwrap();
 }

--- a/flatdata-rs/tests/features/build.rs
+++ b/flatdata-rs/tests/features/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 fn main() {
-    flatdata::generate("../../../test_cases").unwrap();
+    flatdata::generate("../../../test_cases", &env::var("OUT_DIR").unwrap()).unwrap();
 }


### PR DESCRIPTION
Since the packages will be soon published to `PyPI`, we can now rely on `flatdata-generator` being installed by `pip`.

This helps addressing issue #106