### PR TITLE
range field decoration

### DIFF
--- a/docs/schema-language.md
+++ b/docs/schema-language.md
@@ -266,12 +266,12 @@ In this case the edges of a node `i` are then retrieved as
 edges.slice(nodes[i].first_edge_ref..nodes[i + 1].first_edge_ref)
 ```
 Additionally the last element of the `nodes` vector is usually a sentinel (only used to retrieve `first_edge_index`).
-To simplify this flatdata offers the `@range_with_next(name_of_range_attribute)` annotation:
+To simplify this flatdata offers the `@range(name_of_range_attribute)` annotation:
 
 ```cpp
 struct Node {
     ...
-    @range_with_next(edges_range)
+    @range(edges_range)
     first_edge_ref : u32;
 }
 ```

--- a/docs/schema-language.md
+++ b/docs/schema-language.md
@@ -237,3 +237,50 @@ namespace N {
 ```
 
 Local paths must be available in the current namespace.
+
+## Index Ranges
+
+When flattening a data model into a flatdata schema one often encounters
+a pattern of storing index ranges as members of consecutive vector items:
+
+```cpp
+struct Node {
+    ...
+    first_edge_ref : u32;
+}
+
+struct Edge {
+    ...
+}
+
+archive Archive {
+    // contains sentinel
+    @explicit_reference( Nodes.first_edge_ref, edges )
+    nodes : vector< Nodes >;
+    edges : vector< Edges >;
+}
+```
+
+In this case the edges of a node `i` are then retrieved as
+```cpp
+edges.slice(nodes[i].first_edge_ref..nodes[i + 1].first_edge_ref)
+```
+Additionally the last element of the `nodes` vector is usually a sentinel (only used to retrieve `first_edge_index`).
+To simplify this flatdata offers the `@range_with_next(name_of_range_attribute)` annotation:
+
+```cpp
+struct Node {
+    ...
+    @range_with_next(edges_range)
+    first_edge_ref : u32;
+}
+```
+
+This will have two effects:
+* Adding `edges_range` attribute exposing range `(nodes[i].first_edge_ref, nodes[i + 1].first_edge_ref)`
+* Hiding the sentinel in views (it still needs to be populated first, though)
+
+Retrieving all edges is now as easy as this:
+```cpp
+edges.slice(nodes[i].edges_range)
+```

--- a/examples/coappearances/coappearances.flatdata
+++ b/examples/coappearances/coappearances.flatdata
@@ -60,6 +60,7 @@ struct Coappearance {
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
+    @range_with_next(chapters_range)
     first_chapter_ref: u32 : 16;
 }
 

--- a/examples/coappearances/coappearances.flatdata
+++ b/examples/coappearances/coappearances.flatdata
@@ -60,7 +60,7 @@ struct Coappearance {
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
-    @range_with_next(chapters_range)
+    @range(chapters_range)
     first_chapter_ref: u32 : 16;
 }
 

--- a/flatdata-cpp/examples/coappearances/coappearances.cpp
+++ b/flatdata-cpp/examples/coappearances/coappearances.cpp
@@ -360,18 +360,14 @@ read( const char* archive_path )
     auto edges = graph.edges( );
     std::cout << "Coappearances (" << edges.size( ) << "):" << std::endl;
     // Skip the last edge since it is a sentinel
-    for ( uint32_t edge_ref = 0; edge_ref + 1 < edges.size( ); ++edge_ref )
+    for ( auto edge : edges )
     {
-        auto edge = edges[ edge_ref ];
         std::cout << strings + vertices[ edge.a_ref ].name_ref << " meets "
                   << strings + vertices[ edge.b_ref ].name_ref << " " << edge.count
                   << " time(s) in chapters ";
         // The end of the chapters assigned to this edge is the first chapter from the next edge.
         // This is a typical trick when storing ranges. That's why a sentinel was added to edges.
-        uint32_t next_edge_ref = edge_ref + 1;
-        uint32_t chapters_begin = edge.first_chapter_ref;
-        uint32_t chapters_size = edges[ next_edge_ref ].first_chapter_ref - chapters_begin;
-        auto chapters = graph.chapters( ).slice( chapters_begin, chapters_size );
+        auto chapters = graph.chapters( ).slice( edge.chapters_range );
         for ( size_t chapter_ref = 0; chapter_ref < chapters.size( ); ++chapter_ref )
         {
             auto chapter = graph.chapters( )[ chapter_ref ];

--- a/flatdata-cpp/include/flatdata/ArrayView.h
+++ b/flatdata-cpp/include/flatdata/ArrayView.h
@@ -33,6 +33,7 @@ public:
     ConstValueType back( ) const;
 
     ArrayView slice( size_t pos, size_t length ) const;
+    ArrayView slice( std::pair< size_t /*start*/, size_t /*end*/ > range ) const;
     ArrayView slice_before( size_t pos ) const;
     ArrayView slice_after( size_t pos ) const;
 
@@ -48,6 +49,8 @@ public:
     bool empty( ) const;
 
 private:
+    ArrayView( ConstStreamType data, size_t size );
+
     ConstStreamType m_data;
     size_t m_size;
 };

--- a/flatdata-cpp/include/flatdata/MultiVector.h
+++ b/flatdata-cpp/include/flatdata/MultiVector.h
@@ -71,6 +71,10 @@ public:
      */
     View close( );
 
+public:
+    static_assert( all_true< ( !Args::IS_OVERLAPPING_WITH_NEXT )... >::value,
+                   "Cannot use range/overlapping structs in MultiVector" );
+
 private:
     void add_to_index( );
 

--- a/flatdata-cpp/include/flatdata/Struct.h
+++ b/flatdata-cpp/include/flatdata/Struct.h
@@ -26,6 +26,9 @@ public:
     using StreamType = typename T::MutatorType::StreamType;
     using ConstStreamType = typename T::AccessorType::StreamType;
 
+    static_assert( !T::IS_OVERLAPPING_WITH_NEXT,
+                   "Cannot use range/overlapping structs standalone" );
+
 public:
 
     Struct( );

--- a/flatdata-cpp/include/flatdata/internal/Writer.h
+++ b/flatdata-cpp/include/flatdata/internal/Writer.h
@@ -24,14 +24,12 @@ namespace flatdata
  *
  * @note The class expects data streams with 8 byte padding in the end when reading/writing
  */
-template < typename T, int offset = 0, int num_bits = sizeof( T ) * 8 >
+template < typename T, int offset = 0, int num_bits = sizeof( T ) * 8, int struct_size_bytes = 0 >
 struct Writer
 {
     using StreamType = unsigned char*;
-    using UnsignedType =
-        typename BitsToUnsigned< int_choice< num_bits,
-                                             num_bits + offset % 8,
-                                             num_bits + offset % 8 <= 64 >::value >::type;
+    using UnsignedType = typename BitsToUnsigned<
+        int_choice< num_bits, num_bits + offset % 8, num_bits + offset % 8 <= 64 >::value >::type;
     enum
     {
         bit_width = num_bits
@@ -39,7 +37,8 @@ struct Writer
 
     StreamType data;
 
-    Writer& operator=( T t )
+    Writer&
+    operator=( T t )
     {
         /* Does the following:
          * - takes the smallest data type available that can write the necessary amount of bytes
@@ -90,6 +89,16 @@ struct Writer
     {
         return Reader< T, offset, num_bits >{data};
     }
+};
+
+template < typename T, int offset, int num_bits, int struct_size_bytes >
+struct Writer< std::pair< T, T >, offset, num_bits, struct_size_bytes >
+{
+    using StreamType = const unsigned char*;
+
+    StreamType data;
+
+    // We do not support writing to a range, just reading it after the fact
 };
 
 }  // namespace flatdata

--- a/flatdata-cpp/include/flatdata/internal/functional/Utility.h
+++ b/flatdata-cpp/include/flatdata/internal/functional/Utility.h
@@ -70,7 +70,8 @@ struct overload< F > : F
  *          Cf. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72779
  */
 template < typename... Fn >
-overload< Fn... > make_overload( Fn... fn )
+overload< Fn... >
+make_overload( Fn... fn )
 {
     return overload< Fn... >( fn... );
 }
@@ -120,4 +121,10 @@ struct has_args_list
     static const bool value
         = !std::is_same< typename get_args_list< F >::type, static_list::emptylist >::value;
 };
+
+template < bool... >
+struct bool_list;
+
+template < bool... bs >
+using all_true = std::is_same< bool_list< bs..., true >, bool_list< true, bs... > >;
 }  // namespace flatdata

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "test_structures.hpp"
+#include "ranges.hpp"
 
 #include <flatdata/flatdata.h>
 #include "catch.hpp"
@@ -46,4 +47,26 @@ TEST_CASE( "Slicing ArrayView", "[ArrayView]" )
     REQUIRE( view.slice_before( 8 ).front( ).value == 0 );
     REQUIRE( view.slice( 2, 6 ).size( ) == 6 );
     REQUIRE( view.slice( 2, 6 ).front( ).value == 2 );
+}
+
+TEST_CASE( "Slicing ArrayView with Ranges", "[ArrayView]" )
+{
+    Vector< n::S > data( 11 );
+    for ( size_t i = 0; i < 11; i++ )
+    {
+        data[ i ].x = i;
+    }
+
+    ArrayView< n::S > view = data;
+    REQUIRE( view.size( ) == 10 );
+    REQUIRE( view.slice_after( 2 ).size( ) == 8 );
+    REQUIRE( view.slice_after( 2 ).front( ).x == 2 );
+    REQUIRE( view.skip( 2 ).size( ) == 8 );
+    REQUIRE( view.skip( 2 ).front( ).x == 2 );
+    REQUIRE( view.skip_last( 2 ).size( ) == 8 );
+    REQUIRE( view.skip_last( 2 ).front( ).x == 0 );
+    REQUIRE( view.slice_before( 8 ).size( ) == 8 );
+    REQUIRE( view.slice_before( 8 ).front( ).x == 0 );
+    REQUIRE( view.slice( 2, 6 ).size( ) == 6 );
+    REQUIRE( view.slice( 2, 6 ).front( ).x == 2 );
 }

--- a/flatdata-cpp/test/CMakeLists.txt
+++ b/flatdata-cpp/test/CMakeLists.txt
@@ -4,8 +4,12 @@ flatdata_generate_source(generate_flatdata_test_code
     ${CMAKE_CURRENT_SOURCE_DIR}/test_structures.flatdata
     ${CMAKE_CURRENT_BINARY_DIR}/generated/test_structures.hpp)
 
+flatdata_generate_source(generate_flatdata_test_case_ranges
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../test_cases/archives/ranges.flatdata
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/ranges.hpp)
+
 add_executable(flatdata_test ${TEST_FLATDATA_SOURCES})
-add_dependencies(flatdata_test generate_flatdata_test_code)
+add_dependencies(flatdata_test generate_flatdata_test_code generate_flatdata_test_case_ranges)
 
 target_include_directories(flatdata_test
     PRIVATE ${Boost_INCLUDE_DIRS}

--- a/flatdata-cpp/test/GeneratedArchiveTest.cpp
+++ b/flatdata-cpp/test/GeneratedArchiveTest.cpp
@@ -240,7 +240,7 @@ Resource                             Optional  Loaded    Details
 ================================================================================
 object_resource                      NO        YES       Structure of size 1
 vector_resource                      NO        YES       Array of size: 11 in 11 bytes
-multivector_resource                 NO        YES       MultiArray of size 1, with index: Array of size: 2 in 10 bytes
+multivector_resource                 NO        YES       MultiArray of size 1, with index: Array of size: 1 in 10 bytes
 raw_data_resource                    NO        YES       Raw data of size 8
 optional_resource                    YES       YES       Raw data of size 3
 ================================================================================

--- a/flatdata-cpp/test/SerializedStructTest.cpp
+++ b/flatdata-cpp/test/SerializedStructTest.cpp
@@ -3,6 +3,7 @@
  * See the LICENSE file in the root of this project for license details.
  */
 
+#include "ranges.hpp"
 #include "test_structures.hpp"
 
 #include <flatdata/flatdata.h>
@@ -83,6 +84,29 @@ TEST_CASE( "Signed struct works", "[SerializedStruct]" )
     REQUIRE( data[ 7 ] == 0x00 );
     REQUIRE( data[ 8 ] == 0x00 );
     REQUIRE( data[ 9 ] == 0x00 );
+}
+
+TEST_CASE( "Struct with ranges works", "[SerializedStruct]" )
+{
+    Vector< n::S > vec;
+    for ( size_t i = 0; i < 100; i++ )
+    {
+        auto item = vec.grow( );
+        item.x = i;
+        item.first_y = 10 * i;
+    }
+
+    ArrayView< n::S > view = vec;
+    REQUIRE( view.size( ) == 99 );
+
+    for ( size_t i = 0; i < 99; i++ )
+    {
+        REQUIRE( view[ i ].x == i );
+        REQUIRE( view[ i ].first_y == i * 10 );
+        std::pair< uint32_t, uint32_t > range = view[ i ].y_range;
+        REQUIRE( range.first == ( i * 10 ) );
+        REQUIRE( range.second == ( ( i + 1 ) * 10 ) );
+    }
 }
 
 TEST_CASE( "Struct schemas are different", "[SerializedStruct]" )

--- a/flatdata-cpp/test/test_structures.flatdata
+++ b/flatdata-cpp/test/test_structures.flatdata
@@ -71,10 +71,12 @@ struct CStruct {
 }
 
 struct TestIndexType48 {
+    @range_with_next(range)
     value : u64 : 48;
 }
 
 struct TestIndexType32 {
+    @range_with_next(range)
     value : u64 : 48;
 }
 

--- a/flatdata-cpp/test/test_structures.flatdata
+++ b/flatdata-cpp/test/test_structures.flatdata
@@ -71,12 +71,12 @@ struct CStruct {
 }
 
 struct TestIndexType48 {
-    @range_with_next(range)
+    @range(range)
     value : u64 : 48;
 }
 
 struct TestIndexType32 {
-    @range_with_next(range)
+    @range(range)
     value : u64 : 48;
 }
 

--- a/flatdata-generator/flatdata/generator/generators/cpp.py
+++ b/flatdata-generator/flatdata/generator/generators/cpp.py
@@ -50,9 +50,14 @@ class CppGenerator(BaseGenerator):
 
         env.filters["to_type_params"] = _to_type_params
 
+        def _snake_to_upper_camel_case(expr):
+            return ''.join(p.title() for p in expr.split('_'))
+
+        env.filters["snake_to_upper_camel_case"] = _snake_to_upper_camel_case
+
         def _typedef_name(entity, extra_suffix=""):
             assert isinstance(entity, (Field, ResourceBase)), "Got: %s" % entity.__class__
-            return "".join([c.title() for c in entity.name.split('_')]) + extra_suffix + "Type"
+            return _snake_to_upper_camel_case(entity.name) + extra_suffix + "Type"
 
         env.filters["typedef_name"] = _typedef_name
 

--- a/flatdata-generator/flatdata/generator/grammar.py
+++ b/flatdata-generator/flatdata/generator/grammar.py
@@ -43,9 +43,21 @@ enum = Group(
     '}'
 )
 
+range_with_next = Group(
+    Keyword("@range_with_next") +
+    "(" +
+    identifier("name") +
+    ")"
+)
+
+field_decorations = Group(
+    range_with_next("range_with_next")
+)
+
 field = Group(
     Optional(comment)("doc") +
-    identifier("name") +':' -
+    ZeroOrMore(field_decorations)("decorations") +
+    identifier("name") - ':' +
     qualified_identifier("type") +
     Optional(':' + bit_width("width")) +
     ';'

--- a/flatdata-generator/flatdata/generator/grammar.py
+++ b/flatdata-generator/flatdata/generator/grammar.py
@@ -43,15 +43,15 @@ enum = Group(
     '}'
 )
 
-range_with_next = Group(
-    Keyword("@range_with_next") +
+range = Group(
+    Keyword("@range") +
     "(" +
     identifier("name") +
     ")"
 )
 
 field_decorations = Group(
-    range_with_next("range_with_next")
+    range("range")
 )
 
 field = Group(

--- a/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
@@ -1,4 +1,4 @@
-{% set template_header = 'template< template < typename, int, int > class Member >' %}
+{% set template_header = 'template< template < typename, int, int, int > class Member >' %}
 
 {% macro declaration(struct) %}
 {% set template_name = struct.name +'Template' %}
@@ -12,12 +12,16 @@ union {{ template_name }}
 
         {{ field.doc|cpp_doc }}
     {% endif %}
-    using {{ field|typedef_name }} = Member< {{ field.type|cpp_base_type}}, {{ field.offset }}, {{ field.type.width }} >;
+    using {{ field|typedef_name }} = Member< {{ field.type|cpp_base_type}}, {{ field.offset }}, {{ field.type.width }}, {{struct.size_in_bytes}} >;
     {{ field|typedef_name }} {{ field.name }};
+    {% if field.range_with_next %}
+    using {{ field.range_with_next|snake_to_upper_camel_case }}Type = Member< std::pair< {{ field.type|cpp_base_type}}, {{ field.type|cpp_base_type}} >, {{ field.offset }}, {{ field.type.width }}, {{struct.size_in_bytes}} >;
+    {{ field.range_with_next|snake_to_upper_camel_case }}Type {{ field.range_with_next }};
+    {% endif %}
     {% endfor %}
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = {{ template_name }}< flatdata::Writer >;
     /// Immutable structure type
@@ -44,13 +48,15 @@ union {{ template_name }}
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = {{ struct.has_range_with_next|lower}};
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 {{ struct.doc|cpp_doc }}
@@ -69,14 +75,14 @@ namespace internal
 {{ template_header }}
 inline
 {{ template_spec }}::{{ template_name }}( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
 {{ template_header }}
 inline
 {{ template_spec }}::{{ template_name }}( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 

--- a/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
@@ -14,9 +14,9 @@ union {{ template_name }}
     {% endif %}
     using {{ field|typedef_name }} = Member< {{ field.type|cpp_base_type}}, {{ field.offset }}, {{ field.type.width }}, {{struct.size_in_bytes}} >;
     {{ field|typedef_name }} {{ field.name }};
-    {% if field.range_with_next %}
-    using {{ field.range_with_next|snake_to_upper_camel_case }}Type = Member< std::pair< {{ field.type|cpp_base_type}}, {{ field.type|cpp_base_type}} >, {{ field.offset }}, {{ field.type.width }}, {{struct.size_in_bytes}} >;
-    {{ field.range_with_next|snake_to_upper_camel_case }}Type {{ field.range_with_next }};
+    {% if field.range %}
+    using {{ field.range|snake_to_upper_camel_case }}Type = Member< std::pair< {{ field.type|cpp_base_type}}, {{ field.type|cpp_base_type}} >, {{ field.offset }}, {{ field.type.width }}, {{struct.size_in_bytes}} >;
+    {{ field.range|snake_to_upper_camel_case }}Type {{ field.range }};
     {% endif %}
     {% endfor %}
 
@@ -48,7 +48,7 @@ union {{ template_name }}
     std::string to_string( ) const;
     std::string describe( ) const;
 
-    static constexpr bool IS_OVERLAPPING_WITH_NEXT = {{ struct.has_range_with_next|lower}};
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = {{ struct.has_range|lower}};
 
     /**
     * Private data member, should not be directly used.

--- a/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
@@ -2,8 +2,8 @@
 struct {{ struct.name }}
 {
     {% for field in struct.fields %}
-    {% if field.range_with_next %}
-    @range_with_next( {{ field.range_with_next }} )
+    {% if field.range %}
+    @range( {{ field.range }} )
     {% endif %}
     {{ field.name }} : {{field.type.name | field_type}} : {{ field.type.width }};
     {% endfor %}

--- a/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
@@ -2,6 +2,9 @@
 struct {{ struct.name }}
 {
     {% for field in struct.fields %}
+    {% if field.range_with_next %}
+    @range_with_next( {{ field.range_with_next }} )
+    {% endif %}
     {{ field.name }} : {{field.type.name | field_type}} : {{ field.type.width }};
     {% endfor %}
 }

--- a/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
@@ -14,5 +14,11 @@ define_struct!(
     {%- if not loop.last %},
     {% endif %}
     {% endfor %}
+    {% for field in struct.fields %}
+    {%- if field.range_with_next -%}
+    ,
+    range({{ field.range_with_next | escape_rust_keywords }}, {{ field.type.name }}, {{ field.offset }}, {{ field.type.width }})
+    {% endif %}
+    {% endfor %}
 );
 {%- endmacro %}

--- a/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
@@ -15,9 +15,9 @@ define_struct!(
     {% endif %}
     {% endfor %}
     {% for field in struct.fields %}
-    {%- if field.range_with_next -%}
+    {%- if field.range -%}
     ,
-    range({{ field.range_with_next | escape_rust_keywords }}, {{ field.type.name }}, {{ field.offset }}, {{ field.type.width }})
+    range({{ field.range | escape_rust_keywords }}, {{ field.type.name }}, {{ field.offset }}, {{ field.type.width }})
     {% endif %}
     {% endfor %}
 );

--- a/flatdata-generator/flatdata/generator/tree/builder.py
+++ b/flatdata-generator/flatdata/generator/tree/builder.py
@@ -7,12 +7,14 @@ from pyparsing import ParseException, ParseSyntaxException
 
 import flatdata.generator.tree.nodes.trivial as nodes
 from flatdata.generator.grammar import flatdata_grammar
-from flatdata.generator.tree.errors import InvalidEnumWidthError, InvalidRangeName, InvalidRangeReference
+from flatdata.generator.tree.errors import (
+    InvalidEnumWidthError, InvalidRangeName, InvalidRangeReference)
 from flatdata.generator.tree.nodes.archive import Archive
 from flatdata.generator.tree.nodes.node import Node
 from flatdata.generator.tree.syntax_tree import SyntaxTree
 from flatdata.generator.tree.nodes.resources import Multivector, Vector, ResourceBase
-from flatdata.generator.tree.nodes.references import BuiltinStructureReference, ConstantReference, EnumerationReference, StructureReference
+from flatdata.generator.tree.nodes.references import (
+    BuiltinStructureReference, ConstantReference, EnumerationReference, StructureReference)
 from flatdata.generator.tree.nodes.root import Root
 from flatdata.generator.tree.errors import ParsingError
 from flatdata.generator.tree.traversal import DfsTraversal
@@ -20,6 +22,7 @@ from flatdata.generator.tree.helpers.basictype import BasicType
 from flatdata.generator.tree.helpers.enumtype import EnumType
 
 from .resolver import resolve_references
+
 
 def _create_nested_namespaces(path):
     assert not path.startswith(Node.PATH_SEPARATOR)
@@ -152,6 +155,7 @@ def _compute_structure_sizes(root):
             offset += int(field.type.width)
         struct.size_in_bits = offset
 
+
 def _check_ranges(root):
     # First check that names are unique
     for field in root.iterate(nodes.Field):
@@ -160,14 +164,13 @@ def _check_ranges(root):
             continue
         for sibling in field.parent.fields:
             if sibling.name == name:
-                raise InvalidRangeName(name = name)
+                raise InvalidRangeName(name)
 
     # Now check that structs with ranges are only used in vectors
     for reference in root.iterate(StructureReference):
-        if isinstance(reference.node, nodes.Structure) and reference.node.has_range_with_next  \
-            and isinstance(reference.parent, ResourceBase) and not isinstance(reference.parent, Vector):
-                raise InvalidRangeReference(name = reference.target)
-
+        if (isinstance(reference.node, nodes.Structure) and reference.node.has_range_with_next
+                and isinstance(reference.parent, ResourceBase) and not isinstance(reference.parent, Vector)):
+            raise InvalidRangeReference(reference.target)
 
 
 def build_ast(definition):

--- a/flatdata-generator/flatdata/generator/tree/builder.py
+++ b/flatdata-generator/flatdata/generator/tree/builder.py
@@ -159,7 +159,7 @@ def _compute_structure_sizes(root):
 def _check_ranges(root):
     # First check that names are unique
     for field in root.iterate(nodes.Field):
-        name = field.range_with_next
+        name = field.range
         if not name:
             continue
         for sibling in field.parent.fields:
@@ -168,7 +168,7 @@ def _check_ranges(root):
 
     # Now check that structs with ranges are only used in vectors
     for reference in root.iterate(StructureReference):
-        if (isinstance(reference.node, nodes.Structure) and reference.node.has_range_with_next
+        if (isinstance(reference.node, nodes.Structure) and reference.node.has_range
                 and isinstance(reference.parent, ResourceBase) and not isinstance(reference.parent, Vector)):
             raise InvalidRangeReference(reference.target)
 

--- a/flatdata-generator/flatdata/generator/tree/errors.py
+++ b/flatdata-generator/flatdata/generator/tree/errors.py
@@ -112,11 +112,11 @@ class InvalidConstantValueError(FlatdataSyntaxError):
 class InvalidRangeName(FlatdataSyntaxError):
     def __init__(self, name):
         super().__init__(
-            "@range_with_next name {name} is already in use for a field"
+            "@range name {name} is already in use for a field"
             .format(name=name))
 
 class InvalidRangeReference(FlatdataSyntaxError):
     def __init__(self, name):
         super().__init__(
-            "Structs with @range_with_next can only be used in vectors: {name}"
+            "Structs with @range can only be used in vectors: {name}"
             .format(name=name))

--- a/flatdata-generator/flatdata/generator/tree/errors.py
+++ b/flatdata-generator/flatdata/generator/tree/errors.py
@@ -107,3 +107,16 @@ class InvalidConstantValueError(FlatdataSyntaxError):
         super().__init__(
             "Constant {name} has not enough bits for value {value}"
             .format(name=name, value=value))
+
+
+class InvalidRangeName(FlatdataSyntaxError):
+    def __init__(self, name):
+        super().__init__(
+            "@range_with_next name {name} is already in use for a field"
+            .format(name=name))
+
+class InvalidRangeReference(FlatdataSyntaxError):
+    def __init__(self, name):
+        super().__init__(
+            "Structs with @range_with_next can only be used in vectors: {name}"
+            .format(name=name))

--- a/flatdata-generator/flatdata/generator/tree/nodes/resources/multivector.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/resources/multivector.py
@@ -39,12 +39,15 @@ class Multivector(ResourceBase):
 
     @property
     def builtins(self):
-        StructProperties = namedtuple("Properties", ["name", "schema", "doc", "fields"])
-        FieldProperties = namedtuple("Properties", ["name", "width", "type"])
-        properties = StructProperties(
-            name="IndexType{width}".format(width=self._width),
-            schema="struct IndexType%s { value : u64 : %s; }" % (self._width, self._width),
-            doc="/** Builtin type to for MultiVector index */",
-            fields=[FieldProperties(name="value", width=self._width, type="u64")])
+        class MemberDict(dict):
+            def __getattr__(self, attr):
+                return self.get(attr)
+        decorations = [MemberDict({"range_with_next" : MemberDict({"name":"range"})})]
+        field = MemberDict({"decorations":decorations, "name":"value", "width":self._width, "type":"u64"})
+        properties = MemberDict({
+            "name":"IndexType{width}".format(width=self._width),
+            "schema":"struct IndexType%s { value : u64 : %s; }" % (self._width, self._width),
+            "doc":"/** Builtin type to for MultiVector index */",
+            "fields":[field]})
         index_type = Structure.create(properties=properties, definition="")
         return [index_type]

--- a/flatdata-generator/flatdata/generator/tree/nodes/resources/multivector.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/resources/multivector.py
@@ -42,7 +42,7 @@ class Multivector(ResourceBase):
         class MemberDict(dict):
             def __getattr__(self, attr):
                 return self.get(attr)
-        decorations = [MemberDict({"range_with_next" : MemberDict({"name":"range"})})]
+        decorations = [MemberDict({"range" : MemberDict({"name":"range"})})]
         field = MemberDict({"decorations":decorations, "name":"value", "width":self._width, "type":"u64"})
         properties = MemberDict({
             "name":"IndexType{width}".format(width=self._width),

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
@@ -32,10 +32,10 @@ class Field(Node):
                      width=width)
 
     @property
-    def range_with_next(self):
+    def range(self):
         for d in self.decorations:
-            if "range_with_next" in d:
-                return d.range_with_next.name
+            if "range" in d:
+                return d.range.name
         return None
 
     @property

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
@@ -8,6 +8,9 @@ class Field(Node):
         super(Field, self).__init__(name=name, properties=properties)
         self._offset = offset
         self._width = width
+        self._decorations = list()
+        if properties and 'decorations' in properties:
+            self._decorations = properties.decorations
 
         if type is not None:
             if not BasicType.is_basic_type(type):
@@ -27,6 +30,17 @@ class Field(Node):
                      type=properties.type,
                      offset=offset,
                      width=width)
+
+    @property
+    def range_with_next(self):
+        for d in self.decorations:
+            if "range_with_next" in d:
+                return d.range_with_next.name
+        return None
+
+    @property
+    def decorations(self):
+        return self._decorations
 
     @property
     def type(self):

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
@@ -23,10 +23,7 @@ class Structure(Node):
 
     @property
     def has_range_with_next(self):
-        for f in self.fields:
-            if f.range_with_next:
-                return True
-        return False
+        return any(f for f in self.fields if f.range_with_next)
 
     @property
     def doc(self):

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
@@ -22,6 +22,13 @@ class Structure(Node):
         return result
 
     @property
+    def has_range_with_next(self):
+        for f in self.fields:
+            if f.range_with_next:
+                return True
+        return False
+
+    @property
     def doc(self):
         return self._properties.doc
 

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/structure.py
@@ -22,8 +22,8 @@ class Structure(Node):
         return result
 
     @property
-    def has_range_with_next(self):
-        return any(f for f in self.fields if f.range_with_next)
+    def has_range(self):
+        return any(f for f in self.fields if f.range)
 
     @property
     def doc(self):

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
@@ -9,14 +9,14 @@
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union STemplate
 {
-    using XType = Member< uint64_t, 0, 64 >;
+    using XType = Member< uint64_t, 0, 64, 8 >;
     XType x;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = STemplate< flatdata::Writer >;
     /// Immutable structure type
@@ -43,13 +43,15 @@ union STemplate
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -126,14 +128,14 @@ private:
 namespace m { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union STemplate
 {
-    using XType = Member< uint64_t, 0, 64 >;
+    using XType = Member< uint64_t, 0, 64, 8 >;
     XType x;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = STemplate< flatdata::Writer >;
     /// Immutable structure type
@@ -160,13 +162,15 @@ union STemplate
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -243,14 +247,16 @@ private:
 namespace _builtin { namespace multivector { 
 
 /** Builtin type to for MultiVector index */
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union IndexType32Template
 {
-    using ValueType = Member< uint64_t, 0, 32 >;
+    using ValueType = Member< uint64_t, 0, 32, 4 >;
     ValueType value;
+    using RangeType = Member< std::pair< uint64_t, uint64_t >, 0, 32, 4 >;
+    RangeType range;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = IndexType32Template< flatdata::Writer >;
     /// Immutable structure type
@@ -277,13 +283,15 @@ union IndexType32Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = true;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 /** Builtin type to for MultiVector index */
@@ -399,44 +407,44 @@ struct S
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::STemplate( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::STemplate( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename STemplate< Member >::StreamType STemplate< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::schema( ) { return internal::S__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::name( ) { return "S"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t STemplate< Member >::size_in_bytes( ) { return 8; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator==( const STemplate& other ) const
 {
@@ -450,14 +458,14 @@ bool STemplate< Member >::operator==( const STemplate& other ) const
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator!=( const STemplate& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator<( const STemplate& other ) const
 {
@@ -465,14 +473,14 @@ return
     x < other.x ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::operator STemplate< flatdata::Reader >( ) const
 {
     return STemplate< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::to_string( ) const
 {
@@ -484,7 +492,7 @@ std::string STemplate< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::describe( ) const
 {
@@ -638,44 +646,44 @@ struct S
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::STemplate( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::STemplate( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename STemplate< Member >::StreamType STemplate< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::schema( ) { return internal::S__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::name( ) { return "S"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t STemplate< Member >::size_in_bytes( ) { return 8; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator==( const STemplate& other ) const
 {
@@ -689,14 +697,14 @@ bool STemplate< Member >::operator==( const STemplate& other ) const
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator!=( const STemplate& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool STemplate< Member >::operator<( const STemplate& other ) const
 {
@@ -704,14 +712,14 @@ return
     x < other.x ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 STemplate< Member >::operator STemplate< flatdata::Reader >( ) const
 {
     return STemplate< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::to_string( ) const
 {
@@ -723,7 +731,7 @@ std::string STemplate< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string STemplate< Member >::describe( ) const
 {
@@ -870,44 +878,44 @@ namespace internal
     const char* const IndexType32__schema__ = R"schema()schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 IndexType32Template< Member >::IndexType32Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 IndexType32Template< Member >::IndexType32Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 IndexType32Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename IndexType32Template< Member >::StreamType IndexType32Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string IndexType32Template< Member >::schema( ) { return internal::IndexType32__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string IndexType32Template< Member >::name( ) { return "IndexType32"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t IndexType32Template< Member >::size_in_bytes( ) { return 4; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool IndexType32Template< Member >::operator==( const IndexType32Template& other ) const
 {
@@ -921,14 +929,14 @@ bool IndexType32Template< Member >::operator==( const IndexType32Template& other
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool IndexType32Template< Member >::operator!=( const IndexType32Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool IndexType32Template< Member >::operator<( const IndexType32Template& other ) const
 {
@@ -936,14 +944,14 @@ return
     value < other.value ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 IndexType32Template< Member >::operator IndexType32Template< flatdata::Reader >( ) const
 {
     return IndexType32Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string IndexType32Template< Member >::to_string( ) const
 {
@@ -955,7 +963,7 @@ std::string IndexType32Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string IndexType32Template< Member >::describe( ) const
 {

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/ranges.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/ranges.h
@@ -1,18 +1,22 @@
 template< template < typename, int, int, int > class Member >
-union U8Template
+union STemplate
 {
-    using FType = Member< uint8_t, 0, 8, 1 >;
-    FType f;
+    using XType = Member< uint64_t, 0, 64, 10 >;
+    XType x;
+    using FirstYType = Member< uint32_t, 64, 14, 10 >;
+    FirstYType first_y;
+    using YRangeType = Member< std::pair< uint32_t, uint32_t >, 64, 14, 10 >;
+    YRangeType y_range;
 
     /// Stream type accepted by the class
     using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
-    using MutatorType = U8Template< flatdata::Writer >;
+    using MutatorType = STemplate< flatdata::Writer >;
     /// Immutable structure type
-    using AccessorType = U8Template< flatdata::Reader >;
+    using AccessorType = STemplate< flatdata::Reader >;
 
-    U8Template( );
-    explicit U8Template( StreamType data );
+    STemplate( );
+    explicit STemplate( StreamType data );
 
     /// Get raw data stream
     StreamType data( ) const;
@@ -23,16 +27,16 @@ union U8Template
     /// Get structure size in bytes
     static constexpr size_t size_in_bytes( );
 
-    bool operator==( const U8Template& other ) const;
-    bool operator!=( const U8Template& other ) const;
-    bool operator<( const U8Template& other ) const;
-    operator U8Template< flatdata::Reader >( ) const;
+    bool operator==( const STemplate& other ) const;
+    bool operator!=( const STemplate& other ) const;
+    bool operator<( const STemplate& other ) const;
+    operator STemplate< flatdata::Reader >( ) const;
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
     std::string describe( ) const;
 
-    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = true;
 
     /**
     * Private data member, should not be directly used.
@@ -42,8 +46,3 @@ union U8Template
     */
     Member< uint32_t, 0, 0, 0 > _data;
 };
-
-typedef U8Template< flatdata::Reader > U8;
-typedef U8Template< flatdata::Writer > U8Mutator;
-
-} // namespace n

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/default_width.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/default_width.h
@@ -1,5 +1,5 @@
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI8Template
 {
-    using FType = Member< ::n::EnumI8, 0, 8 >;
+    using FType = Member< ::n::EnumI8, 0, 8, 1 >;
     FType f;

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/namespaces.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/namespaces.h.1
@@ -1,6 +1,6 @@
 namespace n { 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union FooTemplate
 {
-    using FType = Member< ::a::Bar, 0, 8 >;
+    using FType = Member< ::a::Bar, 0, 8, 1 >;

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/namespaces.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/namespaces.h.2
@@ -1,6 +1,6 @@
 namespace m { 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union FooTemplate
 {
-    using FType = Member< ::b::Bar, 0, 8 >;
+    using FType = Member< ::b::Bar, 0, 8, 1 >;

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
@@ -22,14 +22,14 @@ const char* to_string( EnumI8 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI8Template
 {
-    using FType = Member< ::n::EnumI8, 0, 1 >;
+    using FType = Member< ::n::EnumI8, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumI8Template< flatdata::Writer >;
     /// Immutable structure type
@@ -56,13 +56,15 @@ union StructEnumI8Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -87,14 +89,14 @@ const char* to_string( EnumU8 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumU8Template
 {
-    using FType = Member< ::n::EnumU8, 0, 1 >;
+    using FType = Member< ::n::EnumU8, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumU8Template< flatdata::Writer >;
     /// Immutable structure type
@@ -121,13 +123,15 @@ union StructEnumU8Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -152,14 +156,14 @@ const char* to_string( EnumI16 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI16Template
 {
-    using FType = Member< ::n::EnumI16, 0, 1 >;
+    using FType = Member< ::n::EnumI16, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumI16Template< flatdata::Writer >;
     /// Immutable structure type
@@ -186,13 +190,15 @@ union StructEnumI16Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -217,14 +223,14 @@ const char* to_string( EnumU16 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumU16Template
 {
-    using FType = Member< ::n::EnumU16, 0, 1 >;
+    using FType = Member< ::n::EnumU16, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumU16Template< flatdata::Writer >;
     /// Immutable structure type
@@ -251,13 +257,15 @@ union StructEnumU16Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -282,14 +290,14 @@ const char* to_string( EnumI32 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI32Template
 {
-    using FType = Member< ::n::EnumI32, 0, 1 >;
+    using FType = Member< ::n::EnumI32, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumI32Template< flatdata::Writer >;
     /// Immutable structure type
@@ -316,13 +324,15 @@ union StructEnumI32Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -347,14 +357,14 @@ const char* to_string( EnumU32 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumU32Template
 {
-    using FType = Member< ::n::EnumU32, 0, 1 >;
+    using FType = Member< ::n::EnumU32, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumU32Template< flatdata::Writer >;
     /// Immutable structure type
@@ -381,13 +391,15 @@ union StructEnumU32Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -412,14 +424,14 @@ const char* to_string( EnumI64 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI64Template
 {
-    using FType = Member< ::n::EnumI64, 0, 1 >;
+    using FType = Member< ::n::EnumI64, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumI64Template< flatdata::Writer >;
     /// Immutable structure type
@@ -446,13 +458,15 @@ union StructEnumI64Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -477,14 +491,14 @@ const char* to_string( EnumU64 value );
 namespace n { 
 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumU64Template
 {
-    using FType = Member< ::n::EnumU64, 0, 1 >;
+    using FType = Member< ::n::EnumU64, 0, 1, 1 >;
     FType f;
 
     /// Stream type accepted by the class
-    using StreamType = typename Member< uint32_t, 0, 0 >::StreamType;
+    using StreamType = typename Member< uint32_t, 0, 0, 0 >::StreamType;
     /// Mutable structure type
     using MutatorType = StructEnumU64Template< flatdata::Writer >;
     /// Immutable structure type
@@ -511,13 +525,15 @@ union StructEnumU64Template
     std::string to_string( ) const;
     std::string describe( ) const;
 
+    static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
+
     /**
     * Private data member, should not be directly used.
     * Cannot be made private.
     * Please refer to C++ Standard, Chapter 9.2, Paragraph 19.
     * This union has to be kept standard-layout, which different access control prevents.
     */
-    Member< uint32_t, 0, 0 > _data;
+    Member< uint32_t, 0, 0, 0 > _data;
 };
 
 
@@ -568,44 +584,44 @@ struct StructEnumI8
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI8Template< Member >::StructEnumI8Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI8Template< Member >::StructEnumI8Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI8Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumI8Template< Member >::StreamType StructEnumI8Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI8Template< Member >::schema( ) { return internal::StructEnumI8__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI8Template< Member >::name( ) { return "StructEnumI8"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumI8Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI8Template< Member >::operator==( const StructEnumI8Template& other ) const
 {
@@ -619,14 +635,14 @@ bool StructEnumI8Template< Member >::operator==( const StructEnumI8Template& oth
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI8Template< Member >::operator!=( const StructEnumI8Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI8Template< Member >::operator<( const StructEnumI8Template& other ) const
 {
@@ -634,14 +650,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI8Template< Member >::operator StructEnumI8Template< flatdata::Reader >( ) const
 {
     return StructEnumI8Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI8Template< Member >::to_string( ) const
 {
@@ -653,7 +669,7 @@ std::string StructEnumI8Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI8Template< Member >::describe( ) const
 {
@@ -700,44 +716,44 @@ struct StructEnumU8
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU8Template< Member >::StructEnumU8Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU8Template< Member >::StructEnumU8Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU8Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumU8Template< Member >::StreamType StructEnumU8Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU8Template< Member >::schema( ) { return internal::StructEnumU8__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU8Template< Member >::name( ) { return "StructEnumU8"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumU8Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU8Template< Member >::operator==( const StructEnumU8Template& other ) const
 {
@@ -751,14 +767,14 @@ bool StructEnumU8Template< Member >::operator==( const StructEnumU8Template& oth
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU8Template< Member >::operator!=( const StructEnumU8Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU8Template< Member >::operator<( const StructEnumU8Template& other ) const
 {
@@ -766,14 +782,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU8Template< Member >::operator StructEnumU8Template< flatdata::Reader >( ) const
 {
     return StructEnumU8Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU8Template< Member >::to_string( ) const
 {
@@ -785,7 +801,7 @@ std::string StructEnumU8Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU8Template< Member >::describe( ) const
 {
@@ -832,44 +848,44 @@ struct StructEnumI16
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI16Template< Member >::StructEnumI16Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI16Template< Member >::StructEnumI16Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI16Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumI16Template< Member >::StreamType StructEnumI16Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI16Template< Member >::schema( ) { return internal::StructEnumI16__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI16Template< Member >::name( ) { return "StructEnumI16"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumI16Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI16Template< Member >::operator==( const StructEnumI16Template& other ) const
 {
@@ -883,14 +899,14 @@ bool StructEnumI16Template< Member >::operator==( const StructEnumI16Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI16Template< Member >::operator!=( const StructEnumI16Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI16Template< Member >::operator<( const StructEnumI16Template& other ) const
 {
@@ -898,14 +914,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI16Template< Member >::operator StructEnumI16Template< flatdata::Reader >( ) const
 {
     return StructEnumI16Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI16Template< Member >::to_string( ) const
 {
@@ -917,7 +933,7 @@ std::string StructEnumI16Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI16Template< Member >::describe( ) const
 {
@@ -964,44 +980,44 @@ struct StructEnumU16
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU16Template< Member >::StructEnumU16Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU16Template< Member >::StructEnumU16Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU16Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumU16Template< Member >::StreamType StructEnumU16Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU16Template< Member >::schema( ) { return internal::StructEnumU16__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU16Template< Member >::name( ) { return "StructEnumU16"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumU16Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU16Template< Member >::operator==( const StructEnumU16Template& other ) const
 {
@@ -1015,14 +1031,14 @@ bool StructEnumU16Template< Member >::operator==( const StructEnumU16Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU16Template< Member >::operator!=( const StructEnumU16Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU16Template< Member >::operator<( const StructEnumU16Template& other ) const
 {
@@ -1030,14 +1046,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU16Template< Member >::operator StructEnumU16Template< flatdata::Reader >( ) const
 {
     return StructEnumU16Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU16Template< Member >::to_string( ) const
 {
@@ -1049,7 +1065,7 @@ std::string StructEnumU16Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU16Template< Member >::describe( ) const
 {
@@ -1096,44 +1112,44 @@ struct StructEnumI32
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI32Template< Member >::StructEnumI32Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI32Template< Member >::StructEnumI32Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI32Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumI32Template< Member >::StreamType StructEnumI32Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI32Template< Member >::schema( ) { return internal::StructEnumI32__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI32Template< Member >::name( ) { return "StructEnumI32"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumI32Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI32Template< Member >::operator==( const StructEnumI32Template& other ) const
 {
@@ -1147,14 +1163,14 @@ bool StructEnumI32Template< Member >::operator==( const StructEnumI32Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI32Template< Member >::operator!=( const StructEnumI32Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI32Template< Member >::operator<( const StructEnumI32Template& other ) const
 {
@@ -1162,14 +1178,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI32Template< Member >::operator StructEnumI32Template< flatdata::Reader >( ) const
 {
     return StructEnumI32Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI32Template< Member >::to_string( ) const
 {
@@ -1181,7 +1197,7 @@ std::string StructEnumI32Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI32Template< Member >::describe( ) const
 {
@@ -1228,44 +1244,44 @@ struct StructEnumU32
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU32Template< Member >::StructEnumU32Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU32Template< Member >::StructEnumU32Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU32Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumU32Template< Member >::StreamType StructEnumU32Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU32Template< Member >::schema( ) { return internal::StructEnumU32__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU32Template< Member >::name( ) { return "StructEnumU32"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumU32Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU32Template< Member >::operator==( const StructEnumU32Template& other ) const
 {
@@ -1279,14 +1295,14 @@ bool StructEnumU32Template< Member >::operator==( const StructEnumU32Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU32Template< Member >::operator!=( const StructEnumU32Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU32Template< Member >::operator<( const StructEnumU32Template& other ) const
 {
@@ -1294,14 +1310,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU32Template< Member >::operator StructEnumU32Template< flatdata::Reader >( ) const
 {
     return StructEnumU32Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU32Template< Member >::to_string( ) const
 {
@@ -1313,7 +1329,7 @@ std::string StructEnumU32Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU32Template< Member >::describe( ) const
 {
@@ -1360,44 +1376,44 @@ struct StructEnumI64
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI64Template< Member >::StructEnumI64Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI64Template< Member >::StructEnumI64Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI64Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumI64Template< Member >::StreamType StructEnumI64Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI64Template< Member >::schema( ) { return internal::StructEnumI64__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI64Template< Member >::name( ) { return "StructEnumI64"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumI64Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI64Template< Member >::operator==( const StructEnumI64Template& other ) const
 {
@@ -1411,14 +1427,14 @@ bool StructEnumI64Template< Member >::operator==( const StructEnumI64Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI64Template< Member >::operator!=( const StructEnumI64Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumI64Template< Member >::operator<( const StructEnumI64Template& other ) const
 {
@@ -1426,14 +1442,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumI64Template< Member >::operator StructEnumI64Template< flatdata::Reader >( ) const
 {
     return StructEnumI64Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI64Template< Member >::to_string( ) const
 {
@@ -1445,7 +1461,7 @@ std::string StructEnumI64Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumI64Template< Member >::describe( ) const
 {
@@ -1492,44 +1508,44 @@ struct StructEnumU64
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU64Template< Member >::StructEnumU64Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU64Template< Member >::StructEnumU64Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU64Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename StructEnumU64Template< Member >::StreamType StructEnumU64Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU64Template< Member >::schema( ) { return internal::StructEnumU64__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU64Template< Member >::name( ) { return "StructEnumU64"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t StructEnumU64Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU64Template< Member >::operator==( const StructEnumU64Template& other ) const
 {
@@ -1543,14 +1559,14 @@ bool StructEnumU64Template< Member >::operator==( const StructEnumU64Template& o
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU64Template< Member >::operator!=( const StructEnumU64Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool StructEnumU64Template< Member >::operator<( const StructEnumU64Template& other ) const
 {
@@ -1558,14 +1574,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 StructEnumU64Template< Member >::operator StructEnumU64Template< flatdata::Reader >( ) const
 {
     return StructEnumU64Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU64Template< Member >::to_string( ) const
 {
@@ -1577,7 +1593,7 @@ std::string StructEnumU64Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string StructEnumU64Template< Member >::describe( ) const
 {

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h.2
@@ -1,5 +1,5 @@
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union StructEnumI8Template
 {
-    using FType = Member< ::n::EnumI8, 0, 1 >;
+    using FType = Member< ::n::EnumI8, 0, 1, 1 >;
     FType f;

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/comments.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/comments.h.1
@@ -1,3 +1,3 @@
 // This is a comment about Foo
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union FooTemplate

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/comments.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/comments.h.2
@@ -1,5 +1,5 @@
 /*
  * This is a comment about Bar
  */
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union BarTemplate

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/default_width.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/default_width.h
@@ -1,4 +1,4 @@
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union U8Template
 {
-    using FType = Member< uint8_t, 0, 8 >;
+    using FType = Member< uint8_t, 0, 8, 1 >;

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
@@ -11,44 +11,44 @@ struct U8
 )schema";
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 U8Template< Member >::U8Template( )
-: _data( Member< uint32_t, 0, 0 >{nullptr} )
+: _data( Member< uint32_t, 0, 0, 0 >{nullptr} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 U8Template< Member >::U8Template( StreamType data )
-: _data( Member< uint32_t, 0, 0 >{data} )
+: _data( Member< uint32_t, 0, 0, 0 >{data} )
 {
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 U8Template< Member >::operator bool( ) const
 {
 return _data.data != nullptr;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 typename U8Template< Member >::StreamType U8Template< Member >::data( ) const { return _data.data; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string U8Template< Member >::schema( ) { return internal::U8__schema__; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string U8Template< Member >::name( ) { return "U8"; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 constexpr size_t U8Template< Member >::size_in_bytes( ) { return 1; }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool U8Template< Member >::operator==( const U8Template& other ) const
 {
@@ -62,14 +62,14 @@ bool U8Template< Member >::operator==( const U8Template& other ) const
     return true;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool U8Template< Member >::operator!=( const U8Template& other ) const
 {
     return !( *this == other );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 bool U8Template< Member >::operator<( const U8Template& other ) const
 {
@@ -77,14 +77,14 @@ return
     f < other.f ;
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 U8Template< Member >::operator U8Template< flatdata::Reader >( ) const
 {
     return U8Template< flatdata::Reader >( _data.data );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string U8Template< Member >::to_string( ) const
 {
@@ -96,7 +96,7 @@ std::string U8Template< Member >::to_string( ) const
     return ss.str( );
 }
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 inline
 std::string U8Template< Member >::describe( ) const
 {

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/namespaces.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/namespaces.h.1
@@ -1,4 +1,4 @@
 namespace n { 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union FooTemplate

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/namespaces.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/namespaces.h.2
@@ -1,4 +1,4 @@
 namespace m { 
 
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union FooTemplate

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/unaligned.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/unaligned.h
@@ -1,7 +1,7 @@
-template< template < typename, int, int > class Member >
+template< template < typename, int, int, int > class Member >
 union U8Template
 {
-    using PaddingType = Member< uint64_t, 0, 3 >;
+    using PaddingType = Member< uint64_t, 0, 3, 1 >;
     PaddingType padding;
-    using FType = Member< uint8_t, 3, 5 >;
+    using FType = Member< uint8_t, 3, 5, 1 >;
     FType f;

--- a/flatdata-generator/tests/generators/flatdata_expectations/archives/ranges.flatdata
+++ b/flatdata-generator/tests/generators/flatdata_expectations/archives/ranges.flatdata
@@ -2,7 +2,7 @@ namespace n {
 struct S
 {
     x : u64 : 64;
-    @range_with_next( y_range )
+    @range( y_range )
     first_y : u32 : 14;
 }
 }

--- a/flatdata-generator/tests/generators/flatdata_expectations/archives/ranges.flatdata
+++ b/flatdata-generator/tests/generators/flatdata_expectations/archives/ranges.flatdata
@@ -1,0 +1,16 @@
+namespace n {
+struct S
+{
+    x : u64 : 64;
+    @range_with_next( y_range )
+    first_y : u32 : 14;
+}
+}
+
+namespace n {
+archive A
+{
+    data : vector< .n.S >;
+}
+}
+

--- a/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
@@ -4,7 +4,7 @@ class n_S(flatdata.structure.Structure):
 struct S
 {
     x : u64 : 64;
-    @range_with_next( y_range )
+    @range( y_range )
     first_y : u32 : 14;
 }
 }

--- a/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
@@ -1,0 +1,22 @@
+class n_S(flatdata.structure.Structure):
+    """"""
+    _SCHEMA = """namespace n {
+struct S
+{
+    x : u64 : 64;
+    @range_with_next( y_range )
+    first_y : u32 : 14;
+}
+}
+
+"""
+    _SIZE_IN_BITS = 78
+    _SIZE_IN_BYTES = 10
+    _FIELDS = {
+        "x": flatdata.structure.FieldSignature(offset=0, width=64, is_signed=False, dtype="u8"),
+        "first_y": flatdata.structure.FieldSignature(offset=64, width=14, is_signed=False, dtype="u4"),
+    }
+    _FIELD_KEYS = {
+        "x",
+        "first_y",
+    }

--- a/flatdata-generator/tests/generators/rust_expectations/archives/ranges.rs
+++ b/flatdata-generator/tests/generators/rust_expectations/archives/ranges.rs
@@ -1,0 +1,25 @@
+define_struct!(
+    S,
+    RefS,
+    RefMutS,
+    schema::structs::S,
+    10,
+    (x, set_x, u64, u64, 0, 64),
+    (first_y, set_first_y, u32, u32, 64, 14),
+    range(y_range, u32, 64, 14)
+);
+
+define_archive!(A, ABuilder,
+    schema::a::A;
+    // struct resources
+;
+    // vector resources
+    (data, set_data, start_data,
+        super::n::S,
+        schema::a::resources::DATA, false);
+    // multivector resources
+;
+    // raw data resources
+;
+    // subarchives
+);

--- a/flatdata-generator/tests/generators/rust_expectations/rustfmt.toml
+++ b/flatdata-generator/tests/generators/rust_expectations/rustfmt.toml
@@ -1,1 +1,5 @@
 disable_all_formatting = true
+ignore = [
+	".",
+	"*"
+]

--- a/flatdata-generator/tests/generators/schemas.py
+++ b/flatdata-generator/tests/generators/schemas.py
@@ -1,6 +1,6 @@
 import os
 
-NUM_TEST_CASES = 23
+NUM_TEST_CASES = 24
 
 def schemas_and_expectations(generator, extension):
     """

--- a/flatdata-generator/tests/generators/test_go_generator.py
+++ b/flatdata-generator/tests/generators/test_go_generator.py
@@ -10,24 +10,27 @@ from .schemas import schemas_and_expectations
 
 from nose.plugins.skip import SkipTest
 
+
 def generate_and_compare(test_case):
     with open(test_case[0], 'r') as test_file:
         test = test_file.read()
 
     expectations = list()
-    for file in  glob.glob(test_case[1] + '*'):
+    for file in glob.glob(test_case[1] + '*'):
         with open(file, 'r') as expectation_file:
             expectations.append(expectation_file.read())
 
     generate_and_assert_in(test, GoGenerator, *expectations)
 
+
 def skip(test_case):
     raise SkipTest("Test %s is skipped" % test_case[0])
 
+
 def test_against_expectations():
     for x in schemas_and_expectations(generator='go', extension='go'):
-        # Go does not yet support namespaces, enums or constants, skip those tests
-        if "enums" not in x[0] and "constants" not in x[0] and "namespaces" not in x[0]:
+        # Go does not yet support namespaces, enums, ranges, or constants, skip those tests
+        if "enums" not in x[0] and "constants" not in x[0] and "namespaces" not in x[0] and "ranges" not in x[0]:
             yield generate_and_compare, x
         else:
             yield skip, x

--- a/flatdata-generator/tests/tree/test_syntax_tree_builder.py
+++ b/flatdata-generator/tests/tree/test_syntax_tree_builder.py
@@ -34,7 +34,7 @@ def test_range_with_duplicate_name():
     with assert_raises(InvalidRangeName):
         build_ast("""namespace foo{
             struct A {
-                @range_with_next(ref_n)
+                @range(ref_n)
                 ref_n : u64 : 64;
             }
             }
@@ -44,7 +44,7 @@ def test_range_cannot_be_used_in_multivector():
     with assert_raises(InvalidRangeReference):
         build_ast("""namespace foo{
             struct A {
-                @range_with_next(my_range)
+                @range(my_range)
                 ref_n : u64 : 64;
             }
             archive R {
@@ -57,7 +57,7 @@ def test_range_cannot_be_used_in_struct_resource():
     with assert_raises(InvalidRangeReference):
         build_ast("""namespace foo{
             struct A {
-                @range_with_next(my_range)
+                @range(my_range)
                 ref_n : u64 : 64;
             }
             archive R {
@@ -69,7 +69,7 @@ def test_range_cannot_be_used_in_struct_resource():
 def test_ranges_can_be_used_in_normally():
     build_ast("""namespace foo{
         struct A {
-            @range_with_next(my_range)
+            @range(my_range)
             ref_n : u64 : 64;
         }
 

--- a/flatdata-rs/lib/src/arrayview.rs
+++ b/flatdata-rs/lib/src/arrayview.rs
@@ -9,7 +9,8 @@ use std::ops::{Bound, RangeBounds};
 /// A read-only view on a contiguous sequence of flatdata structs of the same
 /// type `T`.
 ///
-/// The sequence is written using [`Vector`] or [`ExternalVector`]. For detailed examples see either of the two.
+/// The sequence is written using [`Vector`] or [`ExternalVector`]. For detailed
+/// examples see either of the two.
 ///
 /// An archive provides a getter for each vector resource, which returns an
 /// array view.
@@ -41,7 +42,11 @@ where
 
     /// Number of elements in the array.
     pub fn len(&self) -> usize {
-        self.data.len() / <T as Struct>::SIZE_IN_BYTES
+        if <T as Struct>::IS_OVERLAPPING_WITH_NEXT {
+            self.data.len() / <T as Struct>::SIZE_IN_BYTES - 1
+        } else {
+            self.data.len() / <T as Struct>::SIZE_IN_BYTES
+        }
     }
 
     /// Return `true` if the array is empty.
@@ -56,8 +61,8 @@ where
     ///
     /// Panics if index is greater than or equal to `ArrayView::len()`.
     pub fn at(&self, index: usize) -> <T as Struct<'a>>::Item {
+        assert!(index < self.len());
         let index = self.data_index(index);
-        assert!(index + <T as Struct>::SIZE_IN_BYTES <= self.data.len());
         T::create(&self.data[index..])
     }
 
@@ -72,9 +77,10 @@ where
             Bound::Excluded(&idx) => self.data_index(idx + 1),
             Bound::Unbounded => 0,
         };
+        let extra = <T as Struct>::IS_OVERLAPPING_WITH_NEXT as usize;
         let data_end = match range.end_bound() {
-            Bound::Included(&idx) => self.data_index(idx + 1),
-            Bound::Excluded(&idx) => self.data_index(idx),
+            Bound::Included(&idx) => self.data_index(idx + 1 + extra),
+            Bound::Excluded(&idx) => self.data_index(idx + extra),
             Bound::Unbounded => self.data.len(),
         };
         Self::new(&self.data[data_start..data_end])
@@ -257,6 +263,32 @@ mod test {
         (x, set_x, u32, u32, 0, 16),
         (y, set_y, u32, u32, 16, 16)
     );
+
+    define_struct!(
+        R,
+        RefR,
+        RefMutR,
+        "no_schema",
+        4,
+        (first_x, set_first_x, u32, u32, 0, 16),
+        range(x, u32, 0, 16)
+    );
+
+    #[test]
+    fn range() {
+        let mut vec: Vector<R> = Vector::with_len(3);
+        vec.at_mut(0).set_first_x(10);
+        vec.at_mut(1).set_first_x(20);
+        vec.at_mut(2).set_first_x(30);
+
+        let view = vec.as_view();
+        assert_eq!(view.len(), 2);
+        assert_eq!(view.at(0).x(), 10..20);
+        assert_eq!(view.at(1).x(), 20..30);
+
+        assert_eq!(view.slice(0..1).len(), 1);
+        assert_eq!(view.slice(0..1).at(0).x(), 10..20);
+    }
 
     #[test]
     fn into_iter() {

--- a/flatdata-rs/lib/src/arrayview.rs
+++ b/flatdata-rs/lib/src/arrayview.rs
@@ -79,10 +79,10 @@ where
             Bound::Excluded(&idx) => self.data_index(idx + 1),
             Bound::Unbounded => 0,
         };
-        let extra = <T as Struct>::IS_OVERLAPPING_WITH_NEXT as usize;
+        let sentinel = <T as Struct>::IS_OVERLAPPING_WITH_NEXT as usize;
         let data_end = match range.end_bound() {
-            Bound::Included(&idx) => self.data_index(idx + 1 + extra),
-            Bound::Excluded(&idx) => self.data_index(idx + extra),
+            Bound::Included(&idx) => self.data_index(idx + 1 + sentinel),
+            Bound::Excluded(&idx) => self.data_index(idx + sentinel),
             Bound::Unbounded => self.data.len(),
         };
         Self::new(&self.data[data_start..data_end])

--- a/flatdata-rs/lib/src/multiarrayview.rs
+++ b/flatdata-rs/lib/src/multiarrayview.rs
@@ -44,7 +44,6 @@ where
     /// Note that this is not the *total* number of overall elements stored in
     /// the array. An item may be also empty.
     pub fn len(&self) -> usize {
-        // last index element is a sentinel
         self.index.len()
     }
 

--- a/flatdata-rs/lib/src/multiarrayview.rs
+++ b/flatdata-rs/lib/src/multiarrayview.rs
@@ -3,10 +3,7 @@ use crate::{
     structs::{IndexStruct, VariadicRef, VariadicRefFactory, VariadicStruct},
 };
 
-use std::{
-    fmt, iter, marker,
-    ops::{Bound, RangeBounds},
-};
+use std::{fmt, iter, marker, ops::RangeBounds};
 
 /// A read-only view on a multivector.
 ///

--- a/flatdata-rs/lib/src/multiarrayview.rs
+++ b/flatdata-rs/lib/src/multiarrayview.rs
@@ -4,7 +4,7 @@ use crate::structs::{IndexStruct, VariadicRef, VariadicRefFactory, VariadicStruc
 use std::fmt;
 use std::iter;
 use std::marker;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 
 /// A read-only view on a multivector.
 ///
@@ -46,12 +46,12 @@ where
     /// the array. An item may be also empty.
     pub fn len(&self) -> usize {
         // last index element is a sentinel
-        self.index.len() - 1
+        self.index.len()
     }
 
     /// Returns `true` if no item is stored in the array.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.index.is_empty()
     }
 
     /// Returns a read-only iterator to the elements of the item at position
@@ -61,11 +61,9 @@ where
     ///
     /// Panics if index is greater than or equal to `MultiArrayView::len()`.
     pub fn at(&self, index: usize) -> MultiArrayViewItemIter<'a, Ts> {
-        let start = <<Ts as VariadicStruct<'a>>::Index as IndexStruct>::index(self.index.at(index));
-        let end =
-            <<Ts as VariadicStruct<'a>>::Index as IndexStruct>::index(self.index.at(index + 1));
+        let range = <<Ts as VariadicStruct<'a>>::Index as IndexStruct>::range(self.index.at(index));
         MultiArrayViewItemIter {
-            data: &self.data[start..end],
+            data: &self.data[range],
             _phantom: marker::PhantomData,
         }
     }
@@ -76,18 +74,7 @@ where
     ///
     /// Panics if the range is outside of bounds of array view.
     pub fn slice<R: RangeBounds<usize>>(&self, range: R) -> Self {
-        let index_start = match range.start_bound() {
-            Bound::Included(&idx) => idx,
-            Bound::Excluded(&idx) => idx + 1,
-            Bound::Unbounded => 0,
-        };
-        // include one more element (sentinel)
-        let index_end = match range.end_bound() {
-            Bound::Included(&idx) => idx + 2,
-            Bound::Excluded(&idx) => idx + 1,
-            Bound::Unbounded => self.index.len(),
-        };
-        Self::new(self.index.slice(index_start..index_end), self.data)
+        Self::new(self.index.slice(range), self.data)
     }
 
     /// Returns an iterator through the indexed items of the array.

--- a/flatdata-rs/lib/src/structbuf.rs
+++ b/flatdata-rs/lib/src/structbuf.rs
@@ -2,7 +2,7 @@
 // implementation, since Rust does not allow module names to be one of the
 // language keywords.
 use crate::memory;
-use crate::structs::Struct;
+use crate::structs::{NoOverlap, RefFactory, Struct};
 
 use std::fmt;
 use std::marker;
@@ -77,7 +77,7 @@ use std::marker;
 /// [coappearances]: https://github.com/boxdot/flatdata-rs/blob/master/tests/coappearances_test.rs#L183
 pub struct StructBuf<T>
 where
-    T: for<'a> Struct<'a>,
+    T: RefFactory + NoOverlap,
 {
     data: Vec<u8>,
     _phantom: marker::PhantomData<T>,
@@ -85,7 +85,7 @@ where
 
 impl<T> StructBuf<T>
 where
-    T: for<'a> Struct<'a>,
+    T: RefFactory + NoOverlap,
 {
     /// Creates an empty struct buffer.
     ///
@@ -116,7 +116,7 @@ where
 
 impl<T> fmt::Debug for StructBuf<T>
 where
-    T: for<'a> Struct<'a>,
+    T: RefFactory + NoOverlap,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "StructBuf {{ resource: {:?} }}", self.get())
@@ -125,7 +125,7 @@ where
 
 impl<T> Default for StructBuf<T>
 where
-    T: for<'a> Struct<'a>,
+    T: RefFactory + NoOverlap,
 {
     fn default() -> Self {
         Self::new()
@@ -134,7 +134,7 @@ where
 
 impl<T> AsRef<[u8]> for StructBuf<T>
 where
-    T: for<'a> Struct<'a>,
+    T: RefFactory + NoOverlap,
 {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()

--- a/flatdata-rs/lib/src/structbuf.rs
+++ b/flatdata-rs/lib/src/structbuf.rs
@@ -1,8 +1,10 @@
 // Note: This module is called `structbuf` in contrast to `struct` in the C++
 // implementation, since Rust does not allow module names to be one of the
 // language keywords.
-use crate::{memory, structs::Struct};
-use crate::structs::{NoOverlap, RefFactory, Struct};
+use crate::{
+    memory,
+    structs::{NoOverlap, RefFactory, Struct},
+};
 
 use std::{fmt, marker};
 

--- a/flatdata-rs/lib/src/structs.rs
+++ b/flatdata-rs/lib/src/structs.rs
@@ -52,6 +52,8 @@ pub trait Struct<'a>: Clone {
     const SCHEMA: &'static str;
     /// Size of an object of this type in bytes.
     const SIZE_IN_BYTES: usize;
+    /// Whether this structs requires data of the next instance
+    const IS_OVERLAPPING_WITH_NEXT: bool;
 
     /// Item this factory will produce.
     type Item: Ref;
@@ -72,11 +74,14 @@ pub trait Struct<'a>: Clone {
 pub trait RefFactory: for<'a> Struct<'a> {}
 impl<T> RefFactory for T where T: for<'a> Struct<'a> {}
 
+/// Marks structs that can be used stand-alone, e.g. no range_with_next
+pub trait NoOverlap {}
+
 /// A specialized Struct factory producing Index items.
 /// Used primarily by the MultiVector/MultiArrayView.
 pub trait IndexStruct<'a>: Struct<'a> {
     /// Provide getter for index
-    fn index(data: Self::Item) -> usize;
+    fn range(data: Self::Item) -> std::ops::Range<usize>;
 
     /// Provide setter for index
     fn set_index(data: Self::ItemMut, value: usize);
@@ -146,12 +151,34 @@ impl<T> VariadicRefFactory for T where T: for<'a> VariadicStruct<'a> {}
 // Generator macros
 //
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! has_overlap_due_to_ranges {
+    ($($range:ident),+) => {
+        true
+    };
+    () => {
+        false
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! implement_no_overlap {
+    ($name:ident, $($range:ident),+) => {};
+    ($name:ident,) => {
+        impl $crate::NoOverlap for $name {}
+    };
+}
+
 /// Macro used by generator to define a flatdata struct.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! define_struct {
-    ($factory:ident, $name:ident, $name_mut:ident, $schema:expr, $size_in_bytes:expr
-        $(,($field:ident, $field_setter:ident, $type:path, $primitive_type:tt, $offset:expr, $bit_size:expr))*) =>
+    ($factory:ident, $name:ident, $name_mut:ident, $schema:expr, $size_in_bytes:expr,
+        $(($field:ident, $field_setter:ident, $type:path, $primitive_type:tt, $offset:expr, $bit_size:expr)),*
+        $(,range($range:ident, $range_type:tt, $range_offset:expr, $range_bit_size:expr))*
+    ) =>
     {
         #[derive(Clone, Copy)]
         pub struct $name<'a> {
@@ -166,6 +193,7 @@ macro_rules! define_struct {
         {
             const SCHEMA: &'static str = $schema;
             const SIZE_IN_BYTES: usize = $size_in_bytes;
+            const IS_OVERLAPPING_WITH_NEXT : bool = has_overlap_due_to_ranges!($($range),*);
 
             type Item = $name<'a>;
 
@@ -184,11 +212,19 @@ macro_rules! define_struct {
             }
         }
 
+        implement_no_overlap!($factory, $($range),*);
+
         impl<'a> $name<'a> {
             #[inline]
             $(pub fn $field(&self) -> $type {
                 let value = read_bytes!($primitive_type, self.data, $offset, $bit_size);
                 unsafe { ::std::mem::transmute::<$primitive_type, $type>(value) }
+            })*
+
+            #[inline]
+            $(pub fn $range(&self) -> std::ops::Range<$range_type> {
+                read_bytes!($range_type, self.data, $range_offset, $range_bit_size)..
+                read_bytes!($range_type, self.data, $range_offset + $size_in_bytes * 8, $range_bit_size)
             })*
 
             #[inline]
@@ -241,11 +277,6 @@ macro_rules! define_struct {
             }
 
             #[inline]
-            pub fn into_ref(self) -> $name<'a> {
-                $name{ data : self.data, _phantom : $crate::marker::PhantomData }
-            }
-
-            #[inline]
             pub fn as_ptr(&self) -> *const u8 {
                 self.data
             }
@@ -278,13 +309,15 @@ macro_rules! define_index {
             $name_mut,
             $schema,
             $size_in_bytes,
-            (value, set_value, u64, u64, 0, $size_in_bits)
+            (value, set_value, u64, u64, 0, $size_in_bits),
+            range(range, u64, 0, $size_in_bits)
         );
 
         impl<'a> $crate::IndexStruct<'a> for $factory {
             #[inline]
-            fn index(data: Self::Item) -> usize {
-                data.value() as usize
+            fn range(data: Self::Item) -> std::ops::Range<usize> {
+                let range = data.range();
+                range.start as usize..range.end as usize
             }
 
             #[inline]
@@ -375,6 +408,7 @@ macro_rules! define_variadic_struct {
 mod test {
     use super::super::helper::Int;
     use super::super::structbuf::StructBuf;
+    use super::*;
 
     #[test]
     #[allow(dead_code)]
@@ -394,9 +428,28 @@ mod test {
             (y, set_y, u32, u32, 16, 16),
             (e, set_e, MyEnum, u32, 32, 16)
         );
+        assert_eq!(<A as Struct>::IS_OVERLAPPING_WITH_NEXT, false);
         let a = StructBuf::<A>::new();
         let output = format!("{:?}", a);
         assert_eq!(output, "StructBuf { resource: A { x: 0, y: 0, e: Value } }");
+    }
+
+    #[test]
+    #[allow(dead_code)]
+    fn range_with_next() {
+        // check that this compiles
+        define_struct!(
+            A,
+            RefA,
+            RefMutA,
+            "no_schema",
+            4,
+            (first_x, set_first_x, u32, u32, 0, 16),
+            (y, set_y, u32, u32, 16, 16),
+            range(x, u32, 0, 16)
+        );
+
+        assert_eq!(<A as Struct>::IS_OVERLAPPING_WITH_NEXT, true);
     }
 
     macro_rules! define_enum_test {

--- a/flatdata-rs/lib/src/structs.rs
+++ b/flatdata-rs/lib/src/structs.rs
@@ -75,7 +75,7 @@ pub trait Struct<'a>: Clone {
 pub trait RefFactory: for<'a> Struct<'a> {}
 impl<T> RefFactory for T where T: for<'a> Struct<'a> {}
 
-/// Marks structs that can be used stand-alone, e.g. no range_with_next
+/// Marks structs that can be used stand-alone, e.g. no range
 pub trait NoOverlap {}
 
 /// A specialized Struct factory producing Index items.
@@ -440,7 +440,7 @@ mod test {
 
     #[test]
     #[allow(dead_code)]
-    fn range_with_next() {
+    fn range() {
         // check that this compiles
         define_struct!(
             A,

--- a/flatdata-rs/lib/src/structs.rs
+++ b/flatdata-rs/lib/src/structs.rs
@@ -409,8 +409,10 @@ macro_rules! define_variadic_struct {
 
 #[cfg(test)]
 mod test {
-    use super::super::{helper::Int, structbuf::StructBuf};
-    use super::*;
+    use super::{
+        super::{helper::Int, structbuf::StructBuf},
+        *,
+    };
 
     #[test]
     #[allow(dead_code)]

--- a/flatdata-rs/lib/src/vector.rs
+++ b/flatdata-rs/lib/src/vector.rs
@@ -99,6 +99,13 @@ impl<T> Vector<T>
 where
     T: RefFactory,
 {
+    fn padding() -> usize {
+        if <T as Struct>::IS_OVERLAPPING_WITH_NEXT {
+            <T as Struct>::SIZE_IN_BYTES + memory::PADDING_SIZE
+        } else {
+            memory::PADDING_SIZE
+        }
+    }
     /// Creates an empty `Vector<T>`.
     #[inline]
     pub fn new() -> Self {
@@ -120,7 +127,7 @@ where
     /// Size of the vector in bytes.
     #[inline]
     pub fn size_in_bytes(&self) -> usize {
-        self.data.len() - memory::PADDING_SIZE
+        self.data.len() - Self::padding()
     }
 
     /// Number of elements in the vector.
@@ -186,7 +193,7 @@ where
     /// elements.
     #[inline]
     fn calc_size(len: usize) -> usize {
-        len * <T as Struct>::SIZE_IN_BYTES + memory::PADDING_SIZE
+        len * <T as Struct>::SIZE_IN_BYTES + Self::padding()
     }
 }
 
@@ -363,6 +370,7 @@ where
             .borrow_mut()
             .write(&self.data[..self.data.len() - memory::PADDING_SIZE])?;
         self.data.resize(0, 0);
+
         self.data.resize(memory::PADDING_SIZE, 0);
         Ok(())
     }
@@ -413,10 +421,32 @@ mod tests {
         (y, set_y, u32, u32, 16, 16)
     );
 
+    define_struct!(
+        R,
+        RefR,
+        RefMutR,
+        "no_schema",
+        4,
+        (first_x, set_first_x, u32, u32, 0, 16),
+        range(x, u32, 0, 16)
+    );
+
     #[test]
     fn test_vector_new() {
         let v: Vector<A> = Vector::new();
         assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    fn test_vector_range() {
+        let mut v: Vector<R> = Vector::with_len(3);
+        v.at_mut(0).set_first_x(10);
+        v.at_mut(1).set_first_x(20);
+        v.at_mut(2).set_first_x(30);
+
+        assert_eq!(v.at(0).x(), 10..20);
+        assert_eq!(v.at(1).x(), 20..30);
+        assert_eq!(v.at(2).x(), 30..0);
     }
 
     #[test]

--- a/flatdata-rs/tests/coappearances/assets/karenina.archive/Graph.archive.schema
+++ b/flatdata-rs/tests/coappearances/assets/karenina.archive/Graph.archive.schema
@@ -19,7 +19,7 @@ struct Coappearance
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
-    @range_with_next( chapters_range )
+    @range( chapters_range )
     first_chapter_ref : u32 : 16;
 }
 }

--- a/flatdata-rs/tests/coappearances/assets/karenina.archive/Graph.archive.schema
+++ b/flatdata-rs/tests/coappearances/assets/karenina.archive/Graph.archive.schema
@@ -19,6 +19,7 @@ struct Coappearance
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
+    @range_with_next( chapters_range )
     first_chapter_ref : u32 : 16;
 }
 }

--- a/flatdata-rs/tests/coappearances/assets/karenina.archive/edges.schema
+++ b/flatdata-rs/tests/coappearances/assets/karenina.archive/edges.schema
@@ -4,6 +4,7 @@ struct Coappearance
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
+    @range_with_next( chapters_range )
     first_chapter_ref : u32 : 16;
 }
 }

--- a/flatdata-rs/tests/coappearances/assets/karenina.archive/edges.schema
+++ b/flatdata-rs/tests/coappearances/assets/karenina.archive/edges.schema
@@ -4,7 +4,7 @@ struct Coappearance
     a_ref : u32 : 16;
     b_ref : u32 : 16;
     count : u32 : 16;
-    @range_with_next( chapters_range )
+    @range( chapters_range )
     first_chapter_ref : u32 : 16;
 }
 }

--- a/flatdata-rs/tests/coappearances/src/lib.rs
+++ b/flatdata-rs/tests/coappearances/src/lib.rs
@@ -128,7 +128,7 @@ fn read_and_validate_coappearances() {
     };
 }
 
-fn compare_files(name_a: &path::Path, name_b: &path::Path) {
+fn check_files(name_a: &path::Path, name_b: &path::Path) {
     let mut fa = fs::File::open(name_a).unwrap();
     let mut buf_a = Vec::new();
     fa.read_to_end(&mut buf_a).unwrap();
@@ -140,9 +140,9 @@ fn compare_files(name_a: &path::Path, name_b: &path::Path) {
     assert_eq!(buf_a, buf_b);
 }
 
-fn compare_resource(from: &path::PathBuf, to: &path::PathBuf, resource_name: &str) {
-    compare_files(&from.join(resource_name), &to.join(resource_name));
-    compare_files(
+fn check_resource(from: &path::PathBuf, to: &path::PathBuf, resource_name: &str) {
+    check_files(&from.join(resource_name), &to.join(resource_name));
+    check_files(
         &from.join(format!("{}.schema", resource_name)),
         &to.join(format!("{}.schema", resource_name)),
     );
@@ -171,7 +171,7 @@ fn copy_coappearances_archive(
     let mut meta = flatdata::StructBuf::<coappearances::Meta>::new();
     meta.get_mut().fill_from(&g.meta());
     gb.set_meta(meta.get()).expect("set_meta failed");
-    compare_resource(&source_archive_path, &archive_path, "meta");
+    check_resource(&source_archive_path, &archive_path, "meta");
 
     {
         let mut vertices = gb.start_vertices().expect("start_vertices failed");
@@ -181,7 +181,7 @@ fn copy_coappearances_archive(
         }
         vertices.close().expect("close failed");
     }
-    compare_resource(&source_archive_path, &archive_path, "vertices");
+    check_resource(&source_archive_path, &archive_path, "vertices");
 
     let mut edges = flatdata::Vector::<coappearances::Coappearance>::new();
     for e in g.edges().iter() {
@@ -194,7 +194,7 @@ fn copy_coappearances_archive(
     sentinel.set_b_ref(std::u16::MAX as u32);
     gb.set_edges(&edges.as_view()).expect("set_edges failed");
 
-    compare_resource(&source_archive_path, &archive_path, "edges");
+    check_resource(&source_archive_path, &archive_path, "edges");
 
     {
         let mut vertices_data = gb
@@ -226,8 +226,8 @@ fn copy_coappearances_archive(
         vertices_data.close().expect("close failed");
     }
 
-    compare_resource(&source_archive_path, &archive_path, "vertices_data");
-    compare_resource(&source_archive_path, &archive_path, "vertices_data_index");
+    check_resource(&source_archive_path, &archive_path, "vertices_data");
+    check_resource(&source_archive_path, &archive_path, "vertices_data_index");
 
     let mut chapters = flatdata::Vector::<coappearances::Chapter>::new();
     for ch in g.chapters().iter() {
@@ -236,10 +236,10 @@ fn copy_coappearances_archive(
 
     gb.set_chapters(&chapters.as_view())
         .expect("set_chapters failed");
-    compare_resource(&source_archive_path, &archive_path, "chapters");
+    check_resource(&source_archive_path, &archive_path, "chapters");
 
     gb.set_strings(g.strings()).expect("set_strings failed");
-    compare_resource(&source_archive_path, &archive_path, "strings");
+    check_resource(&source_archive_path, &archive_path, "strings");
 
     (archive_path, gb)
 }

--- a/flatdata-rs/tests/coappearances/src/lib.rs
+++ b/flatdata-rs/tests/coappearances/src/lib.rs
@@ -29,7 +29,7 @@ fn read_and_validate_coappearances() {
     let vertices = g.vertices();
     let edges = g.edges();
     assert_eq!(vertices.len(), 138);
-    assert_eq!(edges.len(), 494);
+    assert_eq!(edges.len(), 493);
 
     // Note: We could use `from_utf8_unchecked` here, which simply does a raw
     // pointer conversion, however we use the safe version of the function,
@@ -70,14 +70,11 @@ fn read_and_validate_coappearances() {
     );
 
     let validate_chapters = |edge_ref, expected| {
-        let e = edges.at(edge_ref);
-        let chapters_start = e.first_chapter_ref() as usize;
-        let chapters_end = edges.at(edge_ref + 1).first_chapter_ref() as usize;
+        let chapters_range = edges.at(edge_ref).chapters_range();
         let e_chapters: Vec<String> = g
             .chapters()
+            .slice(chapters_range.start as usize..chapters_range.end as usize)
             .iter()
-            .skip(chapters_start)
-            .take(chapters_end - chapters_start)
             .map(|ch| format!("{}.{}", ch.major(), ch.minor()))
             .collect();
         assert_eq!(e_chapters, expected);
@@ -90,9 +87,7 @@ fn read_and_validate_coappearances() {
         ],
     );
     validate_chapters(1, vec!["6.19"]);
-    // Note: Last element in edges is not an edge but a sentinel which allows us to
-    // calculate the range of chapter.
-    validate_chapters(edges.len() - 2, vec!["7.25"]);
+    validate_chapters(edges.len() - 1, vec!["7.25"]);
 
     let vertices_data = g.vertices_data();
     assert_eq!(vertices_data.len(), vertices.len());
@@ -137,7 +132,7 @@ fn read_and_validate_coappearances() {
     };
 }
 
-fn compare_files(name_a: &path::Path, name_b: &path::Path) -> bool {
+fn compare_files(name_a: &path::Path, name_b: &path::Path) {
     let mut fa = fs::File::open(name_a).unwrap();
     let mut buf_a = Vec::new();
     fa.read_to_end(&mut buf_a).unwrap();
@@ -146,15 +141,15 @@ fn compare_files(name_a: &path::Path, name_b: &path::Path) -> bool {
     let mut buf_b = Vec::new();
     fb.read_to_end(&mut buf_b).unwrap();
 
-    buf_a == buf_b
+    assert_eq!(buf_a, buf_b);
 }
 
-fn compare_resource(from: &path::PathBuf, to: &path::PathBuf, resource_name: &str) -> bool {
-    compare_files(&from.join(resource_name), &to.join(resource_name))
-        && compare_files(
-            &from.join(format!("{}.schema", resource_name)),
-            &to.join(format!("{}.schema", resource_name)),
-        )
+fn compare_resource(from: &path::PathBuf, to: &path::PathBuf, resource_name: &str) {
+    compare_files(&from.join(resource_name), &to.join(resource_name));
+    compare_files(
+        &from.join(format!("{}.schema", resource_name)),
+        &to.join(format!("{}.schema", resource_name)),
+    );
 }
 
 fn copy_coappearances_archive(
@@ -180,11 +175,7 @@ fn copy_coappearances_archive(
     let mut meta = flatdata::StructBuf::<coappearances::Meta>::new();
     meta.get_mut().fill_from(&g.meta());
     gb.set_meta(meta.get()).expect("set_meta failed");
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "meta"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "meta");
 
     {
         let mut vertices = gb.start_vertices().expect("start_vertices failed");
@@ -194,23 +185,20 @@ fn copy_coappearances_archive(
         }
         vertices.close().expect("close failed");
     }
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "vertices"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "vertices");
 
     let mut edges = flatdata::Vector::<coappearances::Coappearance>::new();
     for e in g.edges().iter() {
         edges.grow().fill_from(&e);
     }
+    // add final sentinel
+    let mut sentinel = edges.grow();
+    sentinel.set_first_chapter_ref(g.edges().at(g.edges().len() - 1).chapters_range().end);
+    sentinel.set_a_ref(std::u16::MAX as u32);
+    sentinel.set_b_ref(std::u16::MAX as u32);
     gb.set_edges(&edges.as_view()).expect("set_edges failed");
 
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "edges"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "edges");
 
     {
         let mut vertices_data = gb
@@ -242,16 +230,8 @@ fn copy_coappearances_archive(
         vertices_data.close().expect("close failed");
     }
 
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "vertices_data"
-    ));
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "vertices_data_index"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "vertices_data");
+    compare_resource(&source_archive_path, &archive_path, "vertices_data_index");
 
     let mut chapters = flatdata::Vector::<coappearances::Chapter>::new();
     for ch in g.chapters().iter() {
@@ -260,18 +240,10 @@ fn copy_coappearances_archive(
 
     gb.set_chapters(&chapters.as_view())
         .expect("set_chapters failed");
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "chapters"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "chapters");
 
     gb.set_strings(g.strings()).expect("set_strings failed");
-    assert!(compare_resource(
-        &source_archive_path,
-        &archive_path,
-        "strings"
-    ));
+    compare_resource(&source_archive_path, &archive_path, "strings");
 
     (archive_path, gb)
 }

--- a/flatdata-rs/tests/features/src/archives/mod.rs
+++ b/flatdata-rs/tests/features/src/archives/mod.rs
@@ -5,3 +5,4 @@ pub mod raw_data;
 pub mod struct_in_archive;
 pub mod subarchive;
 pub mod vector;
+pub mod ranges;

--- a/flatdata-rs/tests/features/src/archives/ranges.rs
+++ b/flatdata-rs/tests/features/src/archives/ranges.rs
@@ -1,0 +1,35 @@
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/archives/ranges.rs"));
+
+#[test]
+fn test() {
+    use flatdata::Archive;
+    use flatdata::ArchiveBuilder;
+
+    let storage = flatdata::MemoryResourceStorage::new("/my_test");
+
+    let mut data = flatdata::Vector::<n::S>::new();
+    for x in 10..600 {
+        let mut next = data.grow();
+        next.set_x(x);
+        next.set_first_y(x as u32 * 10);
+    }
+    assert_eq!(600 - 10, data.len());
+
+    let builder = n::ABuilder::new(storage.clone()).expect("Failed to create builder");
+    builder
+        .set_data(&data.as_view())
+        .expect("Failed to set data");
+
+    let archive = n::A::open(storage).expect("Failed to open archive");
+    let data = archive.data();
+    assert_eq!(599 - 10, data.len());
+    for x in (10..599).enumerate() {
+        assert_eq!(data.at(x.0).x(), x.1);
+        assert_eq!(
+            data.at(x.0).y_range(),
+            (x.1 as u32 * 10..(x.1 as u32 + 1) * 10)
+        );
+    }
+}

--- a/test_cases/archives/ranges.flatdata
+++ b/test_cases/archives/ranges.flatdata
@@ -3,7 +3,7 @@
 namespace n{
 struct S {
 	x : u64;
-	@range_with_next(y_range)
+	@range(y_range)
 	first_y : u32 : 14;
 }
 

--- a/test_cases/archives/ranges.flatdata
+++ b/test_cases/archives/ranges.flatdata
@@ -1,0 +1,13 @@
+/* This test tests that a vector can contain ranges
+ */
+namespace n{
+struct S {
+	x : u64;
+	@range_with_next(y_range)
+	first_y : u32 : 14;
+}
+
+archive A {
+	data : vector< S >;
+}
+}


### PR DESCRIPTION
Related-To: #73 

Add range_with_next, supporting the popular "first_xyz_ref" range referencing pattern

Done:
- generator
- flatdata-rs
- flatdata
- tests
- generator checks against mis-usage: no ranges in multivector, single resource, not name clash, etc
- flatdata-cpp

