### PR TITLE
Limit memory consumption of ExternalVector

### DIFF
--- a/flatdata-cpp/include/flatdata/ExternalVector.h
+++ b/flatdata-cpp/include/flatdata/ExternalVector.h
@@ -83,7 +83,7 @@ template < typename T >
 typename ExternalVector< T >::ValueType
 ExternalVector< T >::grow( )
 {
-    if ( m_data.size( ) > 1024 * 1024 * 32 )
+    if ( m_data.size( ) * sizeof( T ) > 1024 * 1024 * 32 )
     {
         flush( );
     }


### PR DESCRIPTION
This prevents the memory consumption for ExternalVector from
being very high for large objects.