### PR TITLE
Mirror description of flatdata in the rust crate README.

### DIFF
--- a/flatdata-rs/README.md
+++ b/flatdata-rs/README.md
@@ -1,43 +1,52 @@
 # flatdata-rs [![latest version]][crates.io] [![docs]][docs.rs]
 
-Rust implementation of [flatdata](https://github.com/heremaps/flatdata),
-a write-once, read-many, minimal overhead binary structured file format.
+_Write-once, read-many, minimal overhead binary structured file format._
+
+Flatdata is a library providing data structures for convenient creation,
+storage and access of packed memory-mappable structures with minimal overhead.
+
+With `flatdata`, the user defines a schema of the data format using a very
+simple schema language that supports plain structs, vectors and multivectors.
+The schema is then used to generate builders and readers for serialization and
+deserialization of the data to an archive of files on disk.
+
+The data is serialized in a portable way which allows zero-overhead random
+access to it by using memory mapped storage: the operating system facilities
+are used for loading, caching and paging of the data, and most important,
+accessing it as if it were in memory.
 
 ## Example
 
-The folder [tests/coappearances](tests/coappearances) contains a graph of
-character coappearances in Tolstoi's _Anna Karenina_ as flatdata archive schema
-together with the serialized data. The example is taken from the original
-[flatdata repository](https://github.com/heremaps/flatdata). It also contains a
-Rust module which implements the schema. Usually, this code would be generated
-automatically by flatdata's generator.
-
-The standalone tests read and write all different types of data and check that
-the data was de/serialized correctly. Run them simply with:
-
-```shell
-cargo test
-```
+The folder [tests/coappearances] contains a graph of character coappearances in
+Tolstoi's _Anna Karenina_ as flatdata [archive schema] together with the
+serialized data. The standalone tests read and write all different types of
+data and check that the data was de/serialized correctly.
 
 ## Getting started
 
 We recommend that you use a `build.rs` to automatically generate the code from your `flatdata` schema.
 
 ```rust
+// build.rs
 fn main() {
-    flatdata::generate("path/to/my_schema.flatdata").unwrap();
+    flatdata::generate(
+        "path/to/my_schema.flatdata",
+        &std::env::var("OUT_DIR").unwrap(),
+    )
+    .expect("generator failed");
 }
 ```
+
+Then add a module to your crate and include the generated code:
 
 ```rust
 #![allow(dead_code)]
 include!(concat!(env!("OUT_DIR"), "path/to/my_schema.rs"));
-///
 // re-export if desired
 pub use my_schema::*;
 ```
 
-See the [documentation of generator.rs](lib/generator.rs) for a more detailed explaination.
+See the [documentation of generator.rs] for a more detailed explaination.
 
 [travis]: https://travis-ci.org/heremaps/flatdata-rs
 [travis status]: https://travis-ci.org/heremaps/flatdata-rs.svg?branch=master
@@ -45,4 +54,6 @@ See the [documentation of generator.rs](lib/generator.rs) for a more detailed ex
 [crates.io]: https://crates.io/crates/flatdata
 [docs]: https://docs.rs/flatdata/badge.svg
 [docs.rs]: https://docs.rs/flatdata/
-[Why flatdata?]: https://github.com/heremaps/flatdata/blob/master/docs/why-flatdata.md
+[archive schema]: tests/coappearances/assets/coappearances.flatdata
+[tests/coappearances]: tests/coappearances
+[documentation of generator.rs]: lib/src/generator.rs

--- a/flatdata-rs/lib/src/generator.rs
+++ b/flatdata-rs/lib/src/generator.rs
@@ -53,10 +53,10 @@ use std::{env, path::Path, path::PathBuf, process::Command};
 /// picks up the source by setting `FLATDATA_GENERATOR_PATH` to point to the
 /// `flatdata-generator` folder.
 /// ```
-pub fn generate<P>(schemas_path: P, out_dir: P) -> Result<(), GeneratorError>
-where
-    P: AsRef<Path>,
-{
+pub fn generate(
+    schemas_path: impl AsRef<Path>,
+    out_dir: impl AsRef<Path>,
+) -> Result<(), GeneratorError> {
     let schemas_path = schemas_path.as_ref();
     let out_dir = out_dir.as_ref();
 

--- a/flatdata-rs/tests/coappearances/assets/coappearances.flatdata
+++ b/flatdata-rs/tests/coappearances/assets/coappearances.flatdata
@@ -1,0 +1,1 @@
+../../../../examples/coappearances/coappearances.flatdata

--- a/flatdata-rs/tests/coappearances/assets/karenina.json
+++ b/flatdata-rs/tests/coappearances/assets/karenina.json
@@ -1,0 +1,1 @@
+../../../../examples/coappearances/karenina.json

--- a/flatdata-rs/tests/coappearances/build.rs
+++ b/flatdata-rs/tests/coappearances/build.rs
@@ -1,5 +1,7 @@
-use std::env;
-
 fn main() {
-    flatdata::generate("../../../examples/coappearances/coappearances.flatdata", &env::var("OUT_DIR").unwrap()).unwrap();
+    flatdata::generate(
+        "assets/coappearances.flatdata",
+        &std::env::var("OUT_DIR").unwrap(),
+    )
+    .expect("generator failed");
 }

--- a/flatdata-rs/tests/features/build.rs
+++ b/flatdata-rs/tests/features/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-
 fn main() {
-    flatdata::generate("../../../test_cases", &env::var("OUT_DIR").unwrap()).unwrap();
+    flatdata::generate("../../../test_cases", &std::env::var("OUT_DIR").unwrap())
+        .expect("generator failed");
 }


### PR DESCRIPTION
Also:

* Fix getting started example.
* Generalize `flatdata::generate`.