### PR TITLE
Move out `flatdata::generate` to a separate crate `flatdata-gen`.

### DIFF
--- a/flatdata-rs/Cargo.toml
+++ b/flatdata-rs/Cargo.toml
@@ -1,7 +1,10 @@
 [workspace]
-
 members = [
     "lib",
+    "gen",
     "tests/features",
     "tests/coappearances",
 ]
+
+[patch.crates-io]
+flatdata-gen = { path = "gen" }

--- a/flatdata-rs/gen/Cargo.toml
+++ b/flatdata-rs/gen/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "flatdata-gen"
+version = "0.1.0"
+authors = [
+    "boxdot <d@zerovolt.org>",
+    "Christian Vetter <veaac.fdirct@gmail.com>",
+    "Gabriel Féron <feron.gabriel@gmail.com>"
+]
+license = "Apache-2.0"
+description = "Wrapper of flatdata's generator for usage in build.rs"
+repository = "https://github.com/heremaps/flatdata"
+keywords = ["serialization", "flatdata", "mmap", "generator"]
+categories = ["encoding"]
+readme = "../README.md"
+edition = "2018"
+
+[dependencies]
+walkdir = "2.3.1"

--- a/flatdata-rs/gen/src/lib.rs
+++ b/flatdata-rs/gen/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! `build.rs`
 //!
-//! ```ignore
+//! ```rust,no_run
 //! use std::env;
 //!
 //! fn main() {
@@ -39,7 +39,7 @@
 //!
 //! `my_schema.rs`
 //!
-//! ```ignore
+//! ```rust,no_run
 //! #![allow(dead_code)]
 //!
 //! include!(concat!(env!("OUT_DIR"), "/example_a/my_schema.rs"));
@@ -49,6 +49,8 @@
 //! ```
 //!
 //! [flatdata generator]: https://github.com/heremaps/flatdata/tree/master/flatdata-generator
+
+#![doc(test(attr(allow(clippy::needless_doctest_main))))]
 
 use std::{
     env, io,

--- a/flatdata-rs/gen/src/lib.rs
+++ b/flatdata-rs/gen/src/lib.rs
@@ -1,64 +1,78 @@
+//! This crate provides a helper function wrapping the [flatdata generator].
+//!
+//! It can be used to write `build.rs` build scripts, generating outputs either from
+//! a single schema, or recursively from a folder of schemas.
+//!
+//! `schemas_path` can either be a single file, or a filder containing schemas.
+//! In both cases the function will only handle files with the `.flatdata`
+//! extension.
+//!
+//! Generated files are in the same relative location, e.g.
+//! ``` text
+//! schemas_path/
+//! ├────────────example_a/
+//! │            ├─────────my_schema.flatdata
+//! │            └─────────my_other_schema.flatdata
+//! └────────────example_b.flatdata
+//! ```
+//!
+//! results in
+//! ``` text
+//! out_dir/
+//! ├───────example_a/
+//! │       ├─────────my_schema.rs
+//! │       └─────────my_other_schema.rs
+//! └───────example_b.rs
+//! ```
+//!
+//! ## Examples
+//!
+//! `build.rs`
+//!
+//! ```ignore
+//! use std::env;
+//!
+//! fn main() {
+//!     flatdata::generate("schemas_path/", &env::var("OUT_DIR").unwrap()).unwrap();
+//! }
+//! ```
+//!
+//! `my_schema.rs`
+//!
+//! ```ignore
+//! #![allow(dead_code)]
+//!
+//! include!(concat!(env!("OUT_DIR"), "/example_a/my_schema.rs"));
+//!
+//! // re-export if desired
+//! pub use my_schema::*;
+//! ```
+//!
+//! [flatdata generator]: https://github.com/heremaps/flatdata/tree/master/flatdata-generator
+
 use std::{
     env, io,
     path::{Path, PathBuf},
     process::Command,
 };
 
-/// A helper function wrapping the flatdata generator.
+/// Generates Rust code from flatdata schema at `schemas_path` in `out_dir`.
 ///
-/// Can be used to write build.rs build scripts, generating outputs either from
-/// a single schema, or recursively from a folder of schemas.
+/// The `schemas_path` can point to a single schema, or to a folder containing multiple
+/// schemas. In the latter case, the folder is searched for schames recursively.
 ///
-/// `schemas_path` can either be a single file, or a filder containing schemas.
-/// In both cases the function will only handle files with the `.flatdata`
-/// extension.
+/// For examples, see the crate documentation.
 ///
-/// Generated files are in the same relative location, e.g.
-/// ``` text
-/// schemas_path/
-/// ├────────────example_a/
-/// │            ├─────────my_schema.flatdata
-/// │            └─────────my_other_schema.flatdata
-/// └────────────example_b.flatdata
-/// ```
-///
-/// results in
-/// ``` text
-/// out_dir/
-/// ├───────example_a/
-/// │       ├─────────my_schema.rs
-/// │       └─────────my_other_schema.rs
-/// └───────example_b.rs
-/// ```
-///
-/// ## Examples
-///
-/// `build.rs`
-///
-/// ```ignore
-/// use std::env;
-///
-/// fn main() {
-///     flatdata::generate("schemas_path/", &env::var("OUT_DIR").unwrap()).unwrap();
-/// }
-/// ```
-///
-/// `my_schema.rs`
-///
-/// ```ignore
-/// #![allow(dead_code)]
-///
-/// include!(concat!(env!("OUT_DIR"), "/example_a/my_schema.rs"));
-///
-/// // re-export if desired
-/// pub use my_schema::*;
-/// ```
-///
-/// ## Development
+/// # Development
 ///
 /// If you are working on the generator, you can make sure your `build.rs`
 /// script picks up the source by setting `FLATDATA_GENERATOR_PATH` to point to
 /// the `flatdata-generator` folder.
+///
+/// # Implementation detail
+///
+/// The generator is implemented in Python 3. It is installed in virtualenv by `pip3`
+/// locally and used from there.
 pub fn generate(
     schemas_path: impl AsRef<Path>,
     out_dir: impl AsRef<Path>,

--- a/flatdata-rs/lib/Cargo.toml
+++ b/flatdata-rs/lib/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 [dependencies]
 diff = "0.1.11"
 memmap = "0.7.0"
-walkdir = "2.2.9"
 
 [build-dependencies]
 flatdata-gen = "0.1.0"

--- a/flatdata-rs/lib/Cargo.toml
+++ b/flatdata-rs/lib/Cargo.toml
@@ -14,3 +14,6 @@ edition = "2018"
 diff = "0.1.11"
 memmap = "0.7.0"
 walkdir = "2.2.9"
+
+[build-dependencies]
+flatdata-gen = "0.1.0"

--- a/flatdata-rs/lib/src/lib.rs
+++ b/flatdata-rs/lib/src/lib.rs
@@ -266,7 +266,6 @@ mod archive;
 mod arrayview;
 mod error;
 mod filestorage;
-mod generator;
 mod memory;
 mod memstorage;
 mod multiarrayview;
@@ -281,7 +280,6 @@ pub use crate::{
     arrayview::ArrayView,
     error::*,
     filestorage::FileResourceStorage,
-    generator::*,
     memory::PADDING_SIZE,
     memstorage::MemoryResourceStorage,
     multiarrayview::MultiArrayView,

--- a/flatdata-rs/tests/coappearances/Cargo.toml
+++ b/flatdata-rs/tests/coappearances/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 flatdata = { path = "../../lib" }
 
 [build-dependencies]
-flatdata = { path = "../../lib" }
+flatdata-gen = { path = "../../gen" }

--- a/flatdata-rs/tests/coappearances/build.rs
+++ b/flatdata-rs/tests/coappearances/build.rs
@@ -1,7 +1,7 @@
 fn main() {
-    flatdata::generate(
+    flatdata_gen::generate(
         "assets/coappearances.flatdata",
-        &std::env::var("OUT_DIR").unwrap(),
+        std::env::var("OUT_DIR").unwrap(),
     )
     .expect("generator failed");
 }

--- a/flatdata-rs/tests/features/Cargo.toml
+++ b/flatdata-rs/tests/features/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 flatdata = { path = "../../lib" }
 
 [build-dependencies]
-flatdata = { path = "../../lib" }
+flatdata-gen = { path = "../../gen" }

--- a/flatdata-rs/tests/features/build.rs
+++ b/flatdata-rs/tests/features/build.rs
@@ -1,4 +1,4 @@
 fn main() {
-    flatdata::generate("../../../test_cases", &std::env::var("OUT_DIR").unwrap())
+    flatdata_gen::generate("../../../test_cases", &std::env::var("OUT_DIR").unwrap())
         .expect("generator failed");
 }


### PR DESCRIPTION
This allows to generate Rust code from flatdata schemas in the flatdata library itself. (Needed for #160).

Btw. I just realized that this also allows us to integrate standalone `tests` crates as usual integration tests in to the library crate. However, I won't do it now since this would create conflicts with #160.