### PR TITLE
Fix errors in Jinja2

### DIFF
--- a/flatdata-generator/flatdata/generator/templates/cpp/enumeration.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/enumeration.jinja2
@@ -9,7 +9,7 @@ enum class {{ enum.name }} : {{ enum.type|cpp_base_type }}
     {% if value.doc %}
     {{ value.doc|cpp_doc }}
     {% endif %}
-    {{ value.name }} = {{ value.value }} {{ "," if not loop.last }}
+    {{ value.name }} = {{ value.value }}{{ "," if not loop.last }}
     {% endfor %}
 };
 

--- a/flatdata-generator/flatdata/generator/templates/cpp/namespace.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/namespace.jinja2
@@ -1,7 +1,8 @@
 {% macro opening(node) %}
-{% for ns in node|namespaces %}namespace {{ ns.name }} { {% endfor %}
-
+{% for ns in node|namespaces %}namespace {{ ns.name }} {
+{% endfor %}
 {% endmacro %}
+
 {% macro closing(node) %}
 {% for ns in node|namespaces %}}{% endfor %} // namespace {{ node|namespaces|join(".", attribute="name") }}
 {% endmacro %}

--- a/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
@@ -136,7 +136,7 @@ bool {{ template_spec }}::operator<( const {{ struct.name }}Template& other ) co
 {
 return
 {% for member in struct.fields %}
-    {{ member.name }} < other.{{ member.name }} {% if not loop.last %}&&
+    {{ member.name }} < other.{{ member.name }}{% if not loop.last %} &&
 {%endif%}
 {% endfor %};
 }

--- a/flatdata-generator/flatdata/generator/templates/go/archive.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/go/archive.jinja2
@@ -86,9 +86,9 @@ func (v *{{ archive.name|to_go_case }}Archive) ToString() string {
     {% elif resource|is_instance %}
     buffer.WriteString(v.{{ resource.name|to_go_case }}Instance.ToString())
     {% endif %}
-    {% if loop.length != loop.index %}
+    {% if not loop.last %}
     buffer.WriteString(",")
-    {% endif %}      
+    {% endif %}
     {% endfor %}
     buffer.WriteString("]}")
 	return buffer.String()

--- a/flatdata-generator/flatdata/generator/templates/go/go.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/go/go.jinja2
@@ -8,19 +8,19 @@
 {{ go_base.generate(tree, nodes) }}
 
 {% macro structure_definition(tree, struct) %}
-{{ go_struct.generate(tree, struct) }}    
+{{ go_struct.generate(tree, struct) }}
 {% endmacro %}
 
 {% macro archive_definition(tree, archive) %}
 {% for resource in archive.resources if not resource|is_bound_resource %}
 {% if resource|is_instance %}
-{{ go_instance.generate(tree, archive, resource) }}    
+{{ go_instance.generate(tree, archive, resource) }}
 {% elif resource|is_vector %}
 {{ go_vector.generate(tree, archive, resource) }}
 {% elif resource|is_raw_data %}
-{{ go_rawdata.generate(tree, archive, resource) }}    
+{{ go_rawdata.generate(tree, archive, resource) }}
 {% elif resource|is_multivector %}
-{{ go_multivector.generate(tree, archive, resource) }}    
+{{ go_multivector.generate(tree, archive, resource) }}
 {% endif %}
 {% endfor %}
 {{ go_archive.generate(tree, archive) }}

--- a/flatdata-generator/requirements.txt
+++ b/flatdata-generator/requirements.txt
@@ -1,2 +1,2 @@
 pyparsing>=2.0
-jinja2>=2.2
+jinja2>=2.10

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <iomanip>
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -60,7 +60,7 @@ typedef STemplate< flatdata::Writer > SMutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 class X : public flatdata::Archive
 {
@@ -125,7 +125,7 @@ private:
 
 } // namespace n
 
-namespace m { 
+namespace m {
 
 
 template< template < typename, int, int, int > class Member >
@@ -179,7 +179,7 @@ typedef STemplate< flatdata::Writer > SMutator;
 
 } // namespace m
 
-namespace m { 
+namespace m {
 
 class X : public flatdata::Archive
 {
@@ -244,7 +244,8 @@ private:
 
 } // namespace m
 
-namespace _builtin { namespace multivector { 
+namespace _builtin {
+namespace multivector {
 
 /** Builtin type to for MultiVector index */
 template< template < typename, int, int, int > class Member >
@@ -300,7 +301,7 @@ typedef IndexType32Template< flatdata::Writer > IndexType32Mutator;
 
 }} // namespace _builtin.multivector
 
-namespace a { 
+namespace a {
 
 class A : public flatdata::Archive
 {
@@ -394,7 +395,7 @@ private:
 // -------------------------------------- Implementations ------------------------------------------
 // -------------------------------------------------------------------------------------------------
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const S__schema__ = R"schema(namespace n {
@@ -470,7 +471,7 @@ inline
 bool STemplate< Member >::operator<( const STemplate& other ) const
 {
 return
-    x < other.x ;
+    x < other.x;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -502,7 +503,7 @@ std::string STemplate< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
 const char* const X__schema__ =
@@ -633,7 +634,7 @@ XBuilder::set_payload( PayloadReaderType data )
 
 } // namespace n
 
-namespace m { 
+namespace m {
 namespace internal
 {
     const char* const S__schema__ = R"schema(namespace m {
@@ -709,7 +710,7 @@ inline
 bool STemplate< Member >::operator<( const STemplate& other ) const
 {
 return
-    x < other.x ;
+    x < other.x;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -741,7 +742,7 @@ std::string STemplate< Member >::describe( ) const
 }
 } // namespace m
 
-namespace m { 
+namespace m {
 namespace internal
 {
 const char* const X__schema__ =
@@ -872,7 +873,8 @@ XBuilder::set_payload( PayloadReaderType data )
 
 } // namespace m
 
-namespace _builtin { namespace multivector { 
+namespace _builtin {
+namespace multivector {
 namespace internal
 {
     const char* const IndexType32__schema__ = R"schema()schema";
@@ -941,7 +943,7 @@ inline
 bool IndexType32Template< Member >::operator<( const IndexType32Template& other ) const
 {
 return
-    value < other.value ;
+    value < other.value;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -973,7 +975,7 @@ std::string IndexType32Template< Member >::describe( ) const
 }
 }} // namespace _builtin.multivector
 
-namespace a { 
+namespace a {
 namespace internal
 {
 const char* const A__schema__ =

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/comments.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/comments.h.1
@@ -2,7 +2,7 @@
 enum class Foo : uint64_t
 {
     // This is a comment about Foo.a
-    A = 0 ,
+    A = 0,
     // This is a comment about Foo.b
-    B = 1 
+    B = 1
 };

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/comments.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/comments.h.2
@@ -6,9 +6,9 @@ enum class Bar : uint64_t
     /*
          * This is a comment about Bar.a
          */
-    A = 0 ,
+    A = 0,
     /*
      * This is a comment about Bar.b
      */
-    B = 1 
+    B = 1
 };

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/implicit_values.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/implicit_values.h
@@ -1,13 +1,13 @@
 enum class Enum1 : uint16_t
 {
     // = 0
-    VALUE_1 = 0 ,
+    VALUE_1 = 0,
     // = 3
-    VALUE_2 = 3 ,
+    VALUE_2 = 3,
     // = 4
-    VALUE_3 = 4 ,
+    VALUE_3 = 4,
     // = 1
-    VALUE_4 = 1 ,
+    VALUE_4 = 1,
     // = 2
-    VALUE_5 = 2 
+    VALUE_5 = 2
 };

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
@@ -6,11 +6,11 @@
 #include <iostream>
 #include <iomanip>
 
-namespace n { 
+namespace n {
 
 enum class EnumI8 : int8_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -19,7 +19,7 @@ const char* to_string( EnumI8 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -73,11 +73,11 @@ typedef StructEnumI8Template< flatdata::Writer > StructEnumI8Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumU8 : uint8_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -86,7 +86,7 @@ const char* to_string( EnumU8 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -140,11 +140,11 @@ typedef StructEnumU8Template< flatdata::Writer > StructEnumU8Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumI16 : int16_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -153,7 +153,7 @@ const char* to_string( EnumI16 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -207,11 +207,11 @@ typedef StructEnumI16Template< flatdata::Writer > StructEnumI16Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumU16 : uint16_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -220,7 +220,7 @@ const char* to_string( EnumU16 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -274,11 +274,11 @@ typedef StructEnumU16Template< flatdata::Writer > StructEnumU16Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumI32 : int32_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -287,7 +287,7 @@ const char* to_string( EnumI32 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -341,11 +341,11 @@ typedef StructEnumI32Template< flatdata::Writer > StructEnumI32Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumU32 : uint32_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -354,7 +354,7 @@ const char* to_string( EnumU32 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -408,11 +408,11 @@ typedef StructEnumU32Template< flatdata::Writer > StructEnumU32Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumI64 : int64_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -421,7 +421,7 @@ const char* to_string( EnumI64 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -475,11 +475,11 @@ typedef StructEnumI64Template< flatdata::Writer > StructEnumI64Mutator;
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 enum class EnumU64 : uint64_t
 {
-    VALUE = 0 
+    VALUE = 0
 };
 
 inline
@@ -488,7 +488,7 @@ const char* to_string( EnumU64 value );
 
 } // namespace n
 
-namespace n { 
+namespace n {
 
 
 template< template < typename, int, int, int > class Member >
@@ -547,7 +547,7 @@ typedef StructEnumU64Template< flatdata::Writer > StructEnumU64Mutator;
 // -------------------------------------- Implementations ------------------------------------------
 // -------------------------------------------------------------------------------------------------
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumI8 value )
@@ -564,7 +564,7 @@ const char* to_string( EnumI8 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumI8__schema__ = R"schema(namespace n {
@@ -647,7 +647,7 @@ inline
 bool StructEnumI8Template< Member >::operator<( const StructEnumI8Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -679,7 +679,7 @@ std::string StructEnumI8Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumU8 value )
@@ -696,7 +696,7 @@ const char* to_string( EnumU8 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumU8__schema__ = R"schema(namespace n {
@@ -779,7 +779,7 @@ inline
 bool StructEnumU8Template< Member >::operator<( const StructEnumU8Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -811,7 +811,7 @@ std::string StructEnumU8Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumI16 value )
@@ -828,7 +828,7 @@ const char* to_string( EnumI16 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumI16__schema__ = R"schema(namespace n {
@@ -911,7 +911,7 @@ inline
 bool StructEnumI16Template< Member >::operator<( const StructEnumI16Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -943,7 +943,7 @@ std::string StructEnumI16Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumU16 value )
@@ -960,7 +960,7 @@ const char* to_string( EnumU16 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumU16__schema__ = R"schema(namespace n {
@@ -1043,7 +1043,7 @@ inline
 bool StructEnumU16Template< Member >::operator<( const StructEnumU16Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -1075,7 +1075,7 @@ std::string StructEnumU16Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumI32 value )
@@ -1092,7 +1092,7 @@ const char* to_string( EnumI32 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumI32__schema__ = R"schema(namespace n {
@@ -1175,7 +1175,7 @@ inline
 bool StructEnumI32Template< Member >::operator<( const StructEnumI32Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -1207,7 +1207,7 @@ std::string StructEnumI32Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumU32 value )
@@ -1224,7 +1224,7 @@ const char* to_string( EnumU32 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumU32__schema__ = R"schema(namespace n {
@@ -1307,7 +1307,7 @@ inline
 bool StructEnumU32Template< Member >::operator<( const StructEnumU32Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -1339,7 +1339,7 @@ std::string StructEnumU32Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumI64 value )
@@ -1356,7 +1356,7 @@ const char* to_string( EnumI64 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumI64__schema__ = R"schema(namespace n {
@@ -1439,7 +1439,7 @@ inline
 bool StructEnumI64Template< Member >::operator<( const StructEnumI64Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >
@@ -1471,7 +1471,7 @@ std::string StructEnumI64Template< Member >::describe( ) const
 }
 } // namespace n
 
-namespace n { 
+namespace n {
 
 inline
 const char* to_string( EnumU64 value )
@@ -1488,7 +1488,7 @@ const char* to_string( EnumU64 value )
 
 } // namespace n
 
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const StructEnumU64__schema__ = R"schema(namespace n {
@@ -1571,7 +1571,7 @@ inline
 bool StructEnumU64Template< Member >::operator<( const StructEnumU64Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/values.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/values.h.1
@@ -1,9 +1,9 @@
 enum class EnumI8 : int8_t
 {
-    FOO_I8_NEG = -128 ,
-    FOO_I8_POS = 127 ,
-    FOO_I8_ZERO = 0 ,
-    FOO_I8_NEG_HEX = -127 ,
-    FOO_I8_POS_HEX = 126 ,
-    FOO_I8_ONE_HEX = 1 
+    FOO_I8_NEG = -128,
+    FOO_I8_POS = 127,
+    FOO_I8_ZERO = 0,
+    FOO_I8_NEG_HEX = -127,
+    FOO_I8_POS_HEX = 126,
+    FOO_I8_ONE_HEX = 1
 };

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
@@ -1,4 +1,4 @@
-namespace n { 
+namespace n {
 namespace internal
 {
     const char* const U8__schema__ = R"schema(namespace n {
@@ -74,7 +74,7 @@ inline
 bool U8Template< Member >::operator<( const U8Template& other ) const
 {
 return
-    f < other.f ;
+    f < other.f;
 }
 
 template< template < typename, int, int, int > class Member >

--- a/flatdata-generator/tests/generators/go_expectations/archives/subarchive.go
+++ b/flatdata-generator/tests/generators/go_expectations/archives/subarchive.go
@@ -34,7 +34,7 @@ func (v *XPayloadRawData) GetSizeInBytes() int {
 func (v *XPayloadRawData) ToString() string {
     return fmt.Sprintf(`{"container_type": "RawData", "size": %d, "size_in_bytes": %d, "element_types": []}`, v.GetSize(), v.GetSizeInBytes())
 }
-    
+
 type XArchive struct {
     IsOptional bool
     IsOpen bool
@@ -59,8 +59,6 @@ func (v *XArchive) ToString() string {
     buffer := bytes.Buffer{}
     buffer.WriteString(fmt.Sprintf(`{"name": "X", "container_type": "Archive", "size_in_bytes": %d, "resources": [`, v.GetSizeInBytes()))
     buffer.WriteString(v.PayloadRawData.ToString())
-    buffer.WriteString(",")
-      
     buffer.WriteString("]}")
 	return buffer.String()
 }
@@ -134,9 +132,7 @@ func (v *AArchive) ToString() string {
     buffer.WriteString(fmt.Sprintf(`{"name": "A", "container_type": "Archive", "size_in_bytes": %d, "resources": [`, v.GetSizeInBytes()))
     buffer.WriteString(v.DataArchive.ToString())
     buffer.WriteString(",")
-      
     buffer.WriteString(v.OptionalDataArchive.ToString())
-      
     buffer.WriteString("]}")
 	return buffer.String()
 }


### PR DESCRIPTION
* Make whitespaces in C++ templates more robust.
* Fix trailing comma bug in Jinja.
* The minimal compatible Jinja version is 2.10 (tested all version starting with 2.2).

This change is forward compatible with Jinja2 2.11.1.