### PR TITLE
Don't throw an exception in the ResourceHandle destructor

### DIFF
--- a/flatdata-cpp/include/flatdata/internal/ResourceHandle.h
+++ b/flatdata-cpp/include/flatdata/internal/ResourceHandle.h
@@ -21,7 +21,6 @@ namespace flatdata
 class ResourceHandle : private boost::noncopyable
 {
 public:
-    ~ResourceHandle( ) noexcept( false );
     template < typename T >
     void write( T* data, size_t size_in_bytes );
     MemoryDescriptor close( );
@@ -37,15 +36,6 @@ private:
 };
 
 // -------------------------------------------------------------------------------------------------
-
-inline ResourceHandle::~ResourceHandle( ) noexcept( false )
-{
-    if ( m_stream != nullptr )
-    {
-        throw std::logic_error(
-            "Resource not closed before destruction. Close and check for errors." );
-    }
-}
 
 template < typename T >
 void

--- a/flatdata-rs/lib/src/multivector.rs
+++ b/flatdata-rs/lib/src/multivector.rs
@@ -29,8 +29,7 @@ use std::{borrow::BorrowMut, fmt, io, marker};
 /// [`MultiArrayView`].
 ///
 /// A multivector *must* be closed, after the last element was written to it.
-/// After closing, it can not be used anymore. Not closing the multivector will
-/// result in panic on drop (in debug mode).
+/// After closing, it can not be used anymore.
 ///
 /// Internally data is stored like this:
 ///
@@ -207,7 +206,7 @@ where
     /// Flushes the remaining not yet flushed elements in this multivector and
     /// finalizes the data inside the storage.
     ///
-    /// A multivector *must* be closed, otherwise it will panic on drop
+    /// A multivector *must* be closed
     pub fn close(mut self) -> Result<MultiArrayView<'a, Ts>, ResourceStorageError> {
         let name: String = self.data_handle.name().into();
         let into_storage_error = |e| ResourceStorageError::from_io_error(e, name.clone());

--- a/flatdata-rs/lib/src/vector.rs
+++ b/flatdata-rs/lib/src/vector.rs
@@ -225,8 +225,7 @@ where
 /// [`grow`] can be accessed and written.
 ///
 /// An external vector *must* be closed, after the last element was written to
-/// it. After closing, it can not be used anymore. Not closing the vector will
-/// result in panic on drop (in debug mode).
+/// it. After closing, it can not be used anymore.
 ///
 /// # Examples
 /// ``` flatdata
@@ -354,7 +353,7 @@ where
     /// Flushes the remaining not yet flushed elements in this vector and
     /// finalizes the data inside the storage.
     ///
-    /// An external vector *must* be closed, otherwise it will panic on drop
+    /// An external vector *must* be closed
     pub fn close(mut self) -> Result<ArrayView<'a, T>, ResourceStorageError> {
         self.flush().map_err(|e| {
             ResourceStorageError::from_io_error(e, self.resource_handle.name().into())


### PR DESCRIPTION
Throwing exceptions in a destructor is considered bad practice.
See https://isocpp.org/wiki/faq/exceptions#dtors-shouldnt-throw