### PR TITLE
Add @const( <name> ) annotation for fields to indicate which constant is used where

### DIFF
--- a/docs/schema-language.md
+++ b/docs/schema-language.md
@@ -14,6 +14,14 @@ Flatdata supports the following primitive types:
 -  ``i64`` - signed 64-bit wide type
 -  ``u64`` - unsigned 64-bit wide type
 
+## Constants
+
+Flatdata supports defining constants of basic types:
+
+```cpp
+const <type> <name> = <value>;
+```
+
 ## Enumerations
 
 Flatdata supports adding enumeration over basic types. Each enumeration
@@ -23,7 +31,7 @@ starting with 0), or manually.
 Each enumeration is defined as follows:
 
 ```cpp
-enum <Name> : <type> [ : bits ] {
+enum <name> : <type> [ : bits ] {
     <value name> [= value],
     ...
 }
@@ -154,6 +162,23 @@ and create reference edges, while other generators mostly support only
 
 Nonetheless, decorations are first-class citizens of schema and thus are
 validated as well during archive opening.
+
+## Constant Referencing
+
+``@const( <name> )`` can be added to fields of a structure to indicate
+in which locations a constant can appear, e.g.:
+
+```cpp
+const u32 MY_CONST = 10;
+struct MyStruct {
+    @const( MY_CONST )
+    my_value : u32 : 16;
+}
+```
+
+Note: If a constant is not referenced anywhere, flatdata will assume that
+it is a global constant, and include it into the schema of every resource
+of every archive.
 
 ## Optional
 

--- a/flatdata-generator/flatdata/generator/grammar.py
+++ b/flatdata-generator/flatdata/generator/grammar.py
@@ -51,8 +51,16 @@ range = Group(
     ")"
 )
 
+const_ref = Group(
+    Keyword("@const") +
+    "(" +
+    qualified_identifier("name") +
+    ")"
+)
+
 field_decorations = Group(
-    range("range")
+    range("range") |
+    const_ref("const_ref")
 )
 
 field = Group(

--- a/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/flatdata/structure.jinja2
@@ -5,6 +5,9 @@ struct {{ struct.name }}
     {% if field.range %}
     @range( {{ field.range }} )
     {% endif %}
+	{% for const_ref in field.const_refs %}
+    @const( {{ const_ref.target }} )
+    {% endfor %}
     {{ field.name }} : {{field.type.name | field_type}} : {{ field.type.width }};
     {% endfor %}
 }

--- a/flatdata-generator/flatdata/generator/tree/errors.py
+++ b/flatdata-generator/flatdata/generator/tree/errors.py
@@ -113,6 +113,17 @@ class InvalidConstantValueError(FlatdataSyntaxError):
             "Constant {name} has not enough bits for value {value}"
             .format(name=name, value=value))
 
+class InvalidConstReference(FlatdataSyntaxError):
+    def __init__(self, name, type):
+        super().__init__(
+            "Referenced constant {name} has wrong type {type}"
+            .format(name=name, type=type))
+
+class InvalidConstValueReference(FlatdataSyntaxError):
+    def __init__(self, name, bits):
+        super().__init__(
+            "Referenced constant {name} value does not fit into {bits} bits"
+            .format(name=name, bits=bits))
 
 class InvalidRangeName(FlatdataSyntaxError):
     def __init__(self, name):

--- a/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
+++ b/flatdata-generator/flatdata/generator/tree/nodes/trivial/field.py
@@ -1,5 +1,5 @@
 from flatdata.generator.tree.nodes.node import Node
-from flatdata.generator.tree.nodes.references import EnumerationReference
+from flatdata.generator.tree.nodes.references import EnumerationReference, ConstantReference
 from flatdata.generator.tree.helpers.basictype import BasicType
 
 
@@ -11,6 +11,10 @@ class Field(Node):
         self._decorations = list()
         if properties and 'decorations' in properties:
             self._decorations = properties.decorations
+
+        for d in self.decorations:
+            if "const_ref" in d:
+                self.insert(ConstantReference(d.const_ref.name))
 
         if type is not None:
             if not BasicType.is_basic_type(type):
@@ -37,6 +41,10 @@ class Field(Node):
             if "range" in d:
                 return d.range.name
         return None
+
+    @property
+    def const_refs(self):
+        return self.children_like(ConstantReference)
 
     @property
     def decorations(self):

--- a/flatdata-generator/tests/generators/cpp_expectations/constants/namespaces.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/constants/namespaces.h
@@ -1,11 +1,18 @@
-namespace n { 
+namespace n {
 enum : int8_t
 {
     FOO = 0
 };
 } // namespace n
 
-namespace m { 
+namespace n {
+enum : int8_t
+{
+    FOO2 = 10
+};
+} // namespace n
+
+namespace m {
 enum : int8_t
 {
     FOO = 1

--- a/flatdata-generator/tests/generators/flatdata_expectations/constants/namespaces.flatdata
+++ b/flatdata-generator/tests/generators/flatdata_expectations/constants/namespaces.flatdata
@@ -2,7 +2,23 @@ namespace n {
 const i8 FOO = 0;
 }
 
+namespace n {
+const i8 FOO2 = 10;
+}
+
 namespace m {
 const i8 FOO = 1;
+}
+
+namespace m {
+struct Bar
+{
+    @const( .m.FOO )
+    foo1 : i8 : 8;
+    @const( .n.FOO )
+    foo2 : i8 : 8;
+    @const( .m.FOO )
+    foo3 : i8 : 8;
+}
 }
 

--- a/flatdata-generator/tests/generators/rust_expectations/constants/namespaces.rs
+++ b/flatdata-generator/tests/generators/rust_expectations/constants/namespaces.rs
@@ -7,6 +7,8 @@ pub mod structs {
 
 }
 pub const FOO: i8 = 0;
+
+pub const FOO2: i8 = 10;
 }
 
 #[allow(missing_docs)]
@@ -15,8 +17,28 @@ pub mod m {
 #[doc(hidden)]
 pub mod schema {
 pub mod structs {
+pub const BAR: &str = r#"namespace m {
+const i8 FOO = 1;
+}
+
+namespace n {
+const i8 FOO = 0;
+}
+
+namespace m {
+struct Bar
+{
+    @const( .m.FOO )
+    foo1 : i8 : 8;
+    @const( .n.FOO )
+    foo2 : i8 : 8;
+    @const( .m.FOO )
+    foo3 : i8 : 8;
+}
+}
+
+"#;
 }
 
 }
 pub const FOO: i8 = 1;
-}

--- a/test_cases/constants/namespaces.flatdata
+++ b/test_cases/constants/namespaces.flatdata
@@ -2,8 +2,18 @@
  */
 namespace n{
 const i8 FOO = 0;
+const i8 FOO2 = 10;
 }
 
 namespace m{
 const i8 FOO = 1;
+
+struct Bar {
+	@const( FOO )
+	foo1 : i8;
+	@const( .n.FOO )
+	foo2 : i8;
+	@const( .m.FOO )
+	foo3 : i8;
+}
 }


### PR DESCRIPTION
Any constant references this way will only be included in the schema of resources referencing it

Signed-off-by: Christian Vetter <christian.vetter@here.com>