### PR TITLE
Fix Archive::describe to include sub-archives (#188)

### DIFF
--- a/flatdata-cpp/README.md
+++ b/flatdata-cpp/README.md
@@ -4,12 +4,12 @@ C++ 11 implementation of `flatdata`
 
 ## Building
 
-First, build `flatdata-cpp` and install the requirements of the generator.
+First, install the requirements of the generator and build `flatdata-cpp`.
 
 ```shell
-pip3 install -r requirements.txt
-mkdir build
-cd build
+pip3 install -r flatdata-generator/requirements.txt
+cd flatdata-cpp
+mkdir build && cd build
 cmake ..
 make
 make test # optional

--- a/flatdata-cpp/include/flatdata/Archive.h
+++ b/flatdata-cpp/include/flatdata/Archive.h
@@ -151,7 +151,8 @@ Archive::describe_resource( std::ostream& stream,
 {
     auto initialized = static_cast< bool >( resource );
     describe_impl( stream, name, true, initialized ? static_cast< bool >( *resource ) : false,
-                   initialized ? resource->describe( ).c_str( ) : "N/A", too_large );
+                   initialized ? ( std::string( "\n" ) + resource->describe( ) ).c_str( ) : "N/A",
+                   too_large );
 }
 
 template < typename ResourceType >

--- a/flatdata-cpp/include/flatdata/Archive.h
+++ b/flatdata-cpp/include/flatdata/Archive.h
@@ -150,9 +150,19 @@ Archive::describe_resource( std::ostream& stream,
                             bool too_large )
 {
     auto initialized = static_cast< bool >( resource );
+    std::string description;
+    if ( initialized )
+    {
+        description = std::is_base_of< Archive, ResourceType >::value
+                          ? ( std::string( "\n" ) + resource->describe( ) )
+                          : resource->describe( );
+    }
+    else
+    {
+        description = "N/A";
+    }
     describe_impl( stream, name, true, initialized ? static_cast< bool >( *resource ) : false,
-                   initialized ? ( std::string( "\n" ) + resource->describe( ) ).c_str( ) : "N/A",
-                   too_large );
+                   description.c_str( ), too_large );
 }
 
 template < typename ResourceType >

--- a/flatdata-cpp/include/flatdata/Archive.h
+++ b/flatdata-cpp/include/flatdata/Archive.h
@@ -136,26 +136,14 @@ private:
 
 template < typename ResourceType >
 std::string
-get_description( const ResourceType& resource,
-                 bool is_archive,
-                 bool initialized,
-                 size_t nest_level )
+get_description( const ResourceType& resource, bool is_archive, size_t nest_level )
 {
     std::string description;
     if ( is_archive )
     {
         ++nest_level;
     }
-
-    if ( initialized )
-    {
-        description = resource.describe( nest_level );
-    }
-    else
-    {
-        auto dummy = new ResourceType( );
-        description = dummy->describe( nest_level );
-    }
+    description = resource.describe( nest_level );
     return description;
 }
 
@@ -171,8 +159,8 @@ Archive::describe_resource( size_t nest_level,
     const bool is_archive = std::is_base_of< Archive, ResourceType >::value;
 
     describe_impl( stream, name, false, initialized,
-                   get_description( resource, is_archive, initialized, nest_level ).c_str( ),
-                   is_archive, too_large, nest_level );
+                   get_description( resource, is_archive, nest_level ).c_str( ), is_archive,
+                   too_large, nest_level );
 }
 
 template < typename ResourceType >
@@ -186,12 +174,12 @@ Archive::describe_resource( size_t nest_level,
     const auto initialized = static_cast< bool >( resource );
     const bool is_archive = std::is_base_of< Archive, ResourceType >::value;
 
-    const ResourceType ref = initialized ? *resource                  // valid ref
-                                         : *( new ResourceType( ) );  // ref to dummy, not used
+    const ResourceType ref = initialized ? *resource         // valid ref
+                                         : ResourceType( );  // ref to dummy, not used
 
     describe_impl( stream, name, true, initialized ? static_cast< bool >( *resource ) : false,
-                   get_description( ref, is_archive, initialized, nest_level ).c_str( ), is_archive,
-                   too_large, nest_level );
+                   get_description( ref, is_archive, nest_level ).c_str( ), is_archive, too_large,
+                   nest_level );
 }
 
 template < typename ResourceType >

--- a/flatdata-cpp/include/flatdata/Archive.h
+++ b/flatdata-cpp/include/flatdata/Archive.h
@@ -46,7 +46,7 @@ public:
     /**
      * @brief Returns text description of the archive and its resources' state.
      */
-    std::string describe( ) const;
+    std::string describe( size_t nest_level = 0u ) const;
 
     /**
      * @brief Returns archive name. Is implemented by the concrete archive instances.
@@ -60,13 +60,15 @@ public:
 
 protected:
     template < typename ResourceType >
-    static void describe_resource( std::ostream& stream,
+    static void describe_resource( size_t nest_level,
+                                   std::ostream& stream,
                                    const char* name,
                                    const ResourceType& resource,
                                    bool too_large = false );
 
     template < typename ResourceType >
-    static void describe_resource( std::ostream& stream,
+    static void describe_resource( size_t nest_level,
+                                   std::ostream& stream,
                                    const char* name,
                                    const boost::optional< ResourceType >& resource,
                                    bool too_large = false );
@@ -107,7 +109,9 @@ private:
                                bool optional,
                                bool loaded,
                                const char* details,
-                               bool too_large );
+                               bool are_details_nested,
+                               bool too_large,
+                               size_t nest_level );
 
 private:
     /**
@@ -120,7 +124,7 @@ private:
      * @brief Describes all resources provided by the archive.
      * Is implemented by the concrete archive instances.
      */
-    virtual void describe_resources( std::ostream& stream ) const = 0;
+    virtual void describe_resources( std::ostream& stream, size_t nest_level ) const = 0;
 
 private:
     std::shared_ptr< flatdata::ResourceStorage > m_storage;
@@ -131,38 +135,63 @@ private:
 // -------------------------------------------------------------------------------------------------
 
 template < typename ResourceType >
-void
-Archive::describe_resource( std::ostream& stream,
-                            const char* name,
-                            const ResourceType& resource,
-                            bool too_large )
+std::string
+get_description( const ResourceType& resource,
+                 bool is_archive,
+                 bool initialized,
+                 size_t nest_level )
 {
-    auto initialized = static_cast< bool >( resource );
-    describe_impl( stream, name, false, static_cast< bool >( resource ),
-                   initialized ? resource.describe( ).c_str( ) : "N/A", too_large );
+    std::string description;
+    if ( is_archive )
+    {
+        ++nest_level;
+    }
+
+    if ( initialized )
+    {
+        description = resource.describe( nest_level );
+    }
+    else
+    {
+        auto dummy = new ResourceType( );
+        description = dummy->describe( nest_level );
+    }
+    return description;
 }
 
 template < typename ResourceType >
 void
-Archive::describe_resource( std::ostream& stream,
+Archive::describe_resource( size_t nest_level,
+                            std::ostream& stream,
+                            const char* name,
+                            const ResourceType& resource,
+                            bool too_large )
+{
+    const auto initialized = static_cast< bool >( resource );
+    const bool is_archive = std::is_base_of< Archive, ResourceType >::value;
+
+    describe_impl( stream, name, false, initialized,
+                   get_description( resource, is_archive, initialized, nest_level ).c_str( ),
+                   is_archive, too_large, nest_level );
+}
+
+template < typename ResourceType >
+void
+Archive::describe_resource( size_t nest_level,
+                            std::ostream& stream,
                             const char* name,
                             const boost::optional< ResourceType >& resource,
                             bool too_large )
 {
-    auto initialized = static_cast< bool >( resource );
-    std::string description;
-    if ( initialized )
-    {
-        description = std::is_base_of< Archive, ResourceType >::value
-                          ? ( std::string( "\n" ) + resource->describe( ) )
-                          : resource->describe( );
-    }
-    else
-    {
-        description = "N/A";
-    }
+    const auto initialized = static_cast< bool >( resource );
+    const bool is_archive = std::is_base_of< Archive, ResourceType >::value;
+
+    const ResourceType ref = initialized ? *resource                  // valid ref
+                                         : *( new ResourceType( ) );  // ref to dummy, not used
+
     describe_impl( stream, name, true, initialized ? static_cast< bool >( *resource ) : false,
-                   description.c_str( ), too_large );
+                   get_description( ref, is_archive, initialized, nest_level ).c_str( ), is_archive,
+                   too_large, nest_level );
 }
 
 template < typename ResourceType >

--- a/flatdata-cpp/include/flatdata/ArrayView.h
+++ b/flatdata-cpp/include/flatdata/ArrayView.h
@@ -44,7 +44,7 @@ public:
 
     size_t size_in_bytes( ) const;
     size_t size( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0u ) const;
 
     bool empty( ) const;
 

--- a/flatdata-cpp/include/flatdata/ArrayView.h
+++ b/flatdata-cpp/include/flatdata/ArrayView.h
@@ -44,7 +44,7 @@ public:
 
     size_t size_in_bytes( ) const;
     size_t size( ) const;
-    std::string describe( size_t unused = 0u ) const;
+    std::string describe( size_t nest_level = 0u ) const;
 
     bool empty( ) const;
 

--- a/flatdata-cpp/include/flatdata/MemoryDescriptor.h
+++ b/flatdata-cpp/include/flatdata/MemoryDescriptor.h
@@ -31,7 +31,7 @@ public:
     }
 
     std::string
-    describe( size_t unused = 0 ) const
+    describe( size_t nest_level = 0 ) const
     {
         std::ostringstream ss;
         if ( this->operator bool( ) )

--- a/flatdata-cpp/include/flatdata/MemoryDescriptor.h
+++ b/flatdata-cpp/include/flatdata/MemoryDescriptor.h
@@ -31,10 +31,17 @@ public:
     }
 
     std::string
-    describe( ) const
+    describe( size_t unused = 0 ) const
     {
         std::ostringstream ss;
-        ss << "Raw data of size " << m_size;
+        if ( this->operator bool( ) )
+        {
+            ss << "Raw data of size " << m_size;
+        }
+        else
+        {
+            ss << "Uninitialized Raw data";
+        }
         return ss.str( );
     }
 

--- a/flatdata-cpp/include/flatdata/MultiArrayView.h
+++ b/flatdata-cpp/include/flatdata/MultiArrayView.h
@@ -130,7 +130,7 @@ public:
     }
 
     size_t size( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
     explicit operator bool( ) const;
 
     template < typename ElementType >
@@ -195,11 +195,17 @@ MultiArrayView< IndexType, Args... >::size( ) const
 }
 
 template < typename IndexType, typename... Args >
-std::string
-MultiArrayView< IndexType, Args... >::describe( ) const
+std::string MultiArrayView< IndexType, Args... >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "MultiArray of size " << size( ) << ", with index: " << m_index.describe( );
+    if ( this->operator bool( ) )
+    {
+        ss << "MultiArray of size " << size( ) << ", with index: " << m_index.describe( );
+    }
+    else
+    {
+        ss << "Uninitialized MultiArray";
+    }
     return ss.str( );
 }
 

--- a/flatdata-cpp/include/flatdata/internal/ArrayView.inl
+++ b/flatdata-cpp/include/flatdata/internal/ArrayView.inl
@@ -136,11 +136,17 @@ ArrayView< T >::end( ) const
 }
 
 template < typename T >
-std::string
-ArrayView< T >::describe( ) const
+std::string ArrayView< T >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Array of size: " << size( ) << " in " << size_in_bytes( ) << " bytes";
+    if ( !empty( ) )
+    {
+        ss << "Array of size: " << size( ) << " in " << size_in_bytes( ) << " bytes";
+    }
+    else
+    {
+        ss << "Uninitialized Array";
+    }
     return ss.str( );
 }
 

--- a/flatdata-cpp/src/Archive.cpp
+++ b/flatdata-cpp/src/Archive.cpp
@@ -10,6 +10,8 @@
 
 namespace flatdata
 {
+constexpr size_t TAB_WIDTH = 4;
+
 Archive::Archive( std::shared_ptr< flatdata::ResourceStorage > storage )
     : m_storage( std::move( storage ) )
 {
@@ -226,43 +228,63 @@ compute_diff( const char* expected, const char* found )
 }
 
 std::string
-Archive::describe( ) const
+Archive::describe( size_t nest_level ) const
 {
+    const auto newl = std::string( "\n" );
+    const auto hline = std::string( 80, '=' ) + newl;
+    const auto empty = std::string( "" );
+    const bool is_root_node = ( nest_level == 0 );
+
     std::ostringstream result;
-    static const char* hline
-        = "================================================================================";
-    result << hline << std::endl
-           << "Flatdata Archive: " << name( ) << std::endl
-           << hline << std::endl;
+
     if ( !m_storage )
     {
-        result << "  FATAL: Resource storage not initialized. Please check archive path."
-               << std::endl
-               << hline << std::endl;
-        return result.str( );
+        result << ( is_root_node ? hline : empty )
+               << "FATAL: Resource storage not initialized. Please check archive path."
+               << ( is_root_node ? newl : empty );
     }
 
-    if ( !m_signature )
+    if ( m_storage && !m_signature )
     {
-        result << "  FATAL: Archive signature does not match software expectations." << std::endl
-               << hline << std::endl;
+        result << ( is_root_node ? hline : empty )
+               << "FATAL: Archive signature does not match software expectations."
+               << ( is_root_node ? newl : empty ) << hline;
         result << compute_diff(
             schema( ),
             m_storage->read_schema( internal::signature_name( name( ) ).c_str( ) ).char_ptr( ) );
     }
 
-    if ( !m_is_open )
+    if ( m_storage && !m_is_open )
     {
-        result << "  FATAL: Archive initialization failed. Failed loading mandatory resources."
+        // Error propagated to root and storage is not initialized in respective child. No root
+        // check needed.
+        result << hline
+               << "FATAL: Archive initialization failed. Failed loading mandatory resources."
                << std::endl;
     }
 
-    result << std::endl
-           << "Resource                             Optional  Too Large  Loaded    Details"
-           << std::endl
-           << hline << std::endl;
-    describe_resources( result );
-    result << hline << std::endl;
+    if ( is_root_node )
+    {
+        result << hline << "Flatdata Archive: " << name( ) << std::endl
+               << hline
+               << "Resource                             Optional  Too Large  Loaded    Details"
+               << std::endl
+               << hline;
+    }
+    else
+    {
+        const std::string indent( ( nest_level - 1 ) * TAB_WIDTH, ' ' );
+        result << newl + indent + std::string( "|" ) + newl + indent + std::string( "|->" )
+               << " Flatdata Archive: " << name( ) << std::endl;
+    }
+
+    describe_resources( result, nest_level );
+
+    if ( is_root_node )
+    {
+        result << hline;
+    }
+
     return result.str( );
 }
 
@@ -272,17 +294,18 @@ Archive::describe_impl( std::ostream& stream,
                         bool optional,
                         bool loaded,
                         const char* details,
-                        bool too_large )
+                        bool are_details_nested,
+                        bool too_large,
+                        size_t nest_level )
 {
-    auto oldw = stream.width( );
-    auto oldfill = stream.fill( );
-    stream << std::left << std::setw( 37 ) << std::setfill( ' ' )
+    const std::string indent( nest_level * TAB_WIDTH, ' ' );
+    size_t offset = indent.size( );
+    stream << indent << std::left << std::setw( 37 - offset ) << std::setfill( ' ' )
            << std::string( name ).substr( 0, 30 ) << std::left << std::setw( 10 )
            << std::setfill( ' ' ) << ( optional ? "YES" : "NO" ) << std::left << std::setw( 11 )
            << std::setfill( ' ' ) << ( too_large ? "YES" : "NO" ) << std::left << std::setw( 10 )
            << std::setfill( ' ' ) << ( static_cast< bool >( loaded ) ? "YES" : "NO" ) << details
-           << std::endl;
-    stream << std::setw( oldw ) << std::setfill( oldfill );
+           << ( are_details_nested ? "" : "\n" );
 }
 
 }  // namespace flatdata

--- a/flatdata-cpp/src/Archive.cpp
+++ b/flatdata-cpp/src/Archive.cpp
@@ -239,9 +239,15 @@ Archive::describe( size_t nest_level ) const
 
     if ( !m_storage )
     {
-        result << ( is_root_node ? hline : empty )
-               << "FATAL: Resource storage not initialized. Please check archive path."
-               << ( is_root_node ? newl : empty );
+        if ( is_root_node )
+        {
+            result << hline << "FATAL: Resource storage not initialized. Please check archive path."
+                   << newl;
+        }
+        else
+        {
+            result << "Uninitialized Archive " << name( );
+        }
     }
 
     if ( m_storage && !m_signature )
@@ -294,7 +300,7 @@ Archive::describe_impl( std::ostream& stream,
                         bool optional,
                         bool loaded,
                         const char* details,
-                        bool are_details_nested,
+                        bool has_nested_details,
                         bool too_large,
                         size_t nest_level )
 {
@@ -305,7 +311,7 @@ Archive::describe_impl( std::ostream& stream,
            << std::setfill( ' ' ) << ( optional ? "YES" : "NO" ) << std::left << std::setw( 11 )
            << std::setfill( ' ' ) << ( too_large ? "YES" : "NO" ) << std::left << std::setw( 10 )
            << std::setfill( ' ' ) << ( static_cast< bool >( loaded ) ? "YES" : "NO" ) << details
-           << ( are_details_nested ? "" : "\n" );
+           << ( has_nested_details ? "" : "\n" );
 }
 
 }  // namespace flatdata

--- a/flatdata-cpp/test/GeneratedArchiveTest.cpp
+++ b/flatdata-cpp/test/GeneratedArchiveTest.cpp
@@ -330,7 +330,7 @@ TEMPLATE_TEST_CASE_METHOD( Fixture,
 }
 
 TEMPLATE_TEST_CASE_METHOD( Fixture,
-                           "Uninitialized sub-archive is descried",
+                           "Uninitialized sub-archive is described",
                            "[GeneratedArchive]",
                            std::true_type,
                            std::false_type )

--- a/flatdata-cpp/test/GeneratedArchiveTest.cpp
+++ b/flatdata-cpp/test/GeneratedArchiveTest.cpp
@@ -528,6 +528,7 @@ Flatdata Archive: OutermostArchive
 Resource                             Optional  Too Large  Loaded    Details
 ================================================================================
 outermost                            NO        NO         NO        N/A
+outer                                NO        NO         NO        N/A
 ================================================================================
 )";
     REQUIRE( description == expectation );

--- a/flatdata-cpp/test/GeneratedArchiveTest.cpp
+++ b/flatdata-cpp/test/GeneratedArchiveTest.cpp
@@ -356,7 +356,7 @@ Resource                             Optional  Too Large  Loaded    Details
 ================================================================================
 outer1                               NO        NO         YES       Structure of size 1
 outer2                               NO        NO         YES       Structure of size 1
-inner                                NO        NO         NO        FATAL: Resource storage not initialized. Please check archive path.
+inner                                NO        NO         NO        Uninitialized Archive InnerArchive
 |
 |-> Flatdata Archive: InnerArchive
     inner                            NO        NO         NO        Uninitialized Structure AStruct
@@ -390,7 +390,7 @@ Flatdata Archive: OuterWithOptional
 Resource                             Optional  Too Large  Loaded    Details
 ================================================================================
 outer                                NO        NO         YES       Structure of size 1
-archive_resource                     YES       NO         NO        FATAL: Resource storage not initialized. Please check archive path.
+archive_resource                     YES       NO         NO        Uninitialized Archive InnerArchive
 |
 |-> Flatdata Archive: InnerArchive
     inner                            NO        NO         NO        Uninitialized Structure AStruct
@@ -608,12 +608,12 @@ Flatdata Archive: OutermostArchive
 Resource                             Optional  Too Large  Loaded    Details
 ================================================================================
 outermost                            NO        NO         NO        Uninitialized Structure AStruct
-outer                                NO        NO         NO        FATAL: Resource storage not initialized. Please check archive path.
+outer                                NO        NO         NO        Uninitialized Archive OuterArchive
 |
 |-> Flatdata Archive: OuterArchive
     outer1                           NO        NO         NO        Uninitialized Structure AStruct
     outer2                           NO        NO         NO        Uninitialized Structure AStruct
-    inner                            NO        NO         NO        FATAL: Resource storage not initialized. Please check archive path.
+    inner                            NO        NO         NO        Uninitialized Archive InnerArchive
     |
     |-> Flatdata Archive: InnerArchive
         inner                        NO        NO         NO        Uninitialized Structure AStruct
@@ -672,7 +672,7 @@ Flatdata Archive: OuterWithOptional
 Resource                             Optional  Too Large  Loaded    Details
 ================================================================================
 outer                                NO        NO         NO        Uninitialized Structure AStruct
-archive_resource                     YES       NO         NO        FATAL: Resource storage not initialized. Please check archive path.
+archive_resource                     YES       NO         NO        Uninitialized Archive InnerArchive
 |
 |-> Flatdata Archive: InnerArchive
     inner                            NO        NO         NO        Uninitialized Structure AStruct

--- a/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
@@ -165,7 +165,7 @@ inline void
     describe_resource( nest_level, stream, "{{ r.name }}", m_{{ r.name }}{% if r.max_size %}, m_{{ r.name }} && m_{{ r.name }}{%if r.optional %}->{% else %}.{% endif %}size( ) > {{ r.max_size }}{% endif %} );
 {% endfor %}
 {% for r in archive.resources|archive_resources %}
-    describe_resource( nest_level , stream, "{{ r.name }}", m_{{ r.name }} );
+    describe_resource( nest_level, stream, "{{ r.name }}", m_{{ r.name }} );
 {% endfor %}
 }
 

--- a/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
@@ -165,7 +165,7 @@ inline void
     describe_resource( stream, "{{ r.name }}", m_{{ r.name }}{% if r.max_size %}, m_{{ r.name }} && m_{{ r.name }}{%if r.optional %}->{% else %}.{% endif %}size( ) > {{ r.max_size }}{% endif %} );
 {% endfor %}
 {% for r in archive.resources|archive_resources %}
-    describe_resource( stream, "{{ r.name }}", m_{{ r.name }});
+    describe_resource( stream, "{{ r.name }}", m_{{ r.name }} );
 {% endfor %}
 }
 

--- a/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
@@ -164,6 +164,9 @@ inline void
 {% for r in archive.resources|simple_resources %}
     describe_resource( stream, "{{ r.name }}", m_{{ r.name }}{% if r.max_size %}, m_{{ r.name }} && m_{{ r.name }}{%if r.optional %}->{% else %}.{% endif %}size( ) > {{ r.max_size }}{% endif %} );
 {% endfor %}
+{% for r in archive.resources|archive_resources %}
+    describe_resource( stream, "{{ r.name }}", m_{{ r.name }});
+{% endfor %}
 }
 
 {% for r in archive.resources|supported_resources %}

--- a/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/archive.jinja2
@@ -38,7 +38,7 @@ private:
     explicit {{ archive.name }}( std::shared_ptr< flatdata::ResourceStorage > storage );
 
     bool load_contents( ) override;
-    void describe_resources( std::ostream& stream ) const override;
+    void describe_resources( std::ostream& stream, size_t nest_level ) const override;
 
 private:
     {% for r in archive.resources|supported_resources %}
@@ -159,13 +159,13 @@ inline bool
 }
 
 inline void
-{{ archive.name }}::describe_resources( std::ostream& stream ) const
+{{ archive.name }}::describe_resources( std::ostream& stream, size_t nest_level ) const
 {
 {% for r in archive.resources|simple_resources %}
-    describe_resource( stream, "{{ r.name }}", m_{{ r.name }}{% if r.max_size %}, m_{{ r.name }} && m_{{ r.name }}{%if r.optional %}->{% else %}.{% endif %}size( ) > {{ r.max_size }}{% endif %} );
+    describe_resource( nest_level, stream, "{{ r.name }}", m_{{ r.name }}{% if r.max_size %}, m_{{ r.name }} && m_{{ r.name }}{%if r.optional %}->{% else %}.{% endif %}size( ) > {{ r.max_size }}{% endif %} );
 {% endfor %}
 {% for r in archive.resources|archive_resources %}
-    describe_resource( stream, "{{ r.name }}", m_{{ r.name }} );
+    describe_resource( nest_level , stream, "{{ r.name }}", m_{{ r.name }} );
 {% endfor %}
 }
 

--- a/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
@@ -51,7 +51,7 @@ union {{ template_name }}
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = {{ struct.has_range|lower}};
 
@@ -176,10 +176,17 @@ std::string {{ template_spec }}::to_string( ) const
 
 {{ template_header }}
 inline
-std::string {{ template_spec }}::describe( ) const
+std::string {{ template_spec }}::describe( size_t unused ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool() )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 {% endmacro %}

--- a/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/cpp/structure.jinja2
@@ -51,7 +51,7 @@ union {{ template_name }}
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( size_t unused = 0) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = {{ struct.has_range|lower}};
 
@@ -176,10 +176,10 @@ std::string {{ template_spec }}::to_string( ) const
 
 {{ template_header }}
 inline
-std::string {{ template_spec }}::describe( size_t unused ) const
+std::string {{ template_spec }}::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    if( this->operator bool() )
+    if( this->operator bool( ) )
     {
         ss << "Structure of size " << size_in_bytes( );
     }

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/empty.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/empty.h
@@ -25,7 +25,7 @@ private:
     explicit A( std::shared_ptr< flatdata::ResourceStorage > storage );
 
     bool load_contents( ) override;
-    void describe_resources( std::ostream& stream ) const override;
+    void describe_resources( std::ostream& stream, size_t nest_level ) const override;
 
 private:
 };

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
@@ -1135,6 +1135,7 @@ A::describe_resources( std::ostream& stream ) const
     describe_resource( stream, "single", m_single );
     describe_resource( stream, "list", m_list );
     describe_resource( stream, "multi", m_multi );
+    describe_resource( stream, "inner", m_inner );
 }
 
 inline auto A::single( ) const -> const SingleType&

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/namespaces.h
@@ -41,7 +41,7 @@ union STemplate
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -92,7 +92,7 @@ private:
     explicit X( std::shared_ptr< flatdata::ResourceStorage > storage );
 
     bool load_contents( ) override;
-    void describe_resources( std::ostream& stream ) const override;
+    void describe_resources( std::ostream& stream, size_t nest_level ) const override;
 
 private:
     PayloadType m_payload;
@@ -160,7 +160,7 @@ union STemplate
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -211,7 +211,7 @@ private:
     explicit X( std::shared_ptr< flatdata::ResourceStorage > storage );
 
     bool load_contents( ) override;
-    void describe_resources( std::ostream& stream ) const override;
+    void describe_resources( std::ostream& stream, size_t nest_level ) const override;
 
 private:
     PayloadType m_payload;
@@ -282,7 +282,7 @@ union IndexType32Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = true;
 
@@ -342,7 +342,7 @@ private:
     explicit A( std::shared_ptr< flatdata::ResourceStorage > storage );
 
     bool load_contents( ) override;
-    void describe_resources( std::ostream& stream ) const override;
+    void describe_resources( std::ostream& stream, size_t nest_level ) const override;
 
 private:
     SingleType m_single;
@@ -495,10 +495,17 @@ std::string STemplate< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string STemplate< Member >::describe( ) const
+std::string STemplate< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -576,9 +583,9 @@ X::load_contents( )
 }
 
 inline void
-X::describe_resources( std::ostream& stream ) const
+X::describe_resources( std::ostream& stream, size_t nest_level ) const
 {
-    describe_resource( stream, "payload", m_payload );
+    describe_resource( nest_level, stream, "payload", m_payload );
 }
 
 inline auto X::payload( ) const -> const PayloadType&
@@ -734,10 +741,17 @@ std::string STemplate< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string STemplate< Member >::describe( ) const
+std::string STemplate< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace m
@@ -815,9 +829,9 @@ X::load_contents( )
 }
 
 inline void
-X::describe_resources( std::ostream& stream ) const
+X::describe_resources( std::ostream& stream, size_t nest_level ) const
 {
-    describe_resource( stream, "payload", m_payload );
+    describe_resource( nest_level, stream, "payload", m_payload );
 }
 
 inline auto X::payload( ) const -> const PayloadType&
@@ -967,10 +981,17 @@ std::string IndexType32Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string IndexType32Template< Member >::describe( ) const
+std::string IndexType32Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 }} // namespace _builtin.multivector
@@ -1130,12 +1151,12 @@ A::load_contents( )
 }
 
 inline void
-A::describe_resources( std::ostream& stream ) const
+A::describe_resources( std::ostream& stream, size_t nest_level ) const
 {
-    describe_resource( stream, "single", m_single );
-    describe_resource( stream, "list", m_list );
-    describe_resource( stream, "multi", m_multi );
-    describe_resource( stream, "inner", m_inner );
+    describe_resource( nest_level, stream, "single", m_single );
+    describe_resource( nest_level, stream, "list", m_list );
+    describe_resource( nest_level, stream, "multi", m_multi );
+    describe_resource( nest_level, stream, "inner", m_inner );
 }
 
 inline auto A::single( ) const -> const SingleType&

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/ranges.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/ranges.h
@@ -34,7 +34,7 @@ union STemplate
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = true;
 

--- a/flatdata-generator/tests/generators/cpp_expectations/archives/references.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/archives/references.h.1
@@ -21,14 +21,14 @@ A::load_contents( )
 }
 
 inline void
-A::describe_resources( std::ostream& stream ) const
+A::describe_resources( std::ostream& stream, size_t nest_level ) const
 {
-    describe_resource( stream, "list1", m_list1, m_list1 && m_list1->size( ) > 16 );
-    describe_resource( stream, "list2", m_list2, m_list2 && m_list2.size( ) > 16 );
-    describe_resource( stream, "multilist1", m_multilist1, m_multilist1 && m_multilist1->size( ) > 16 );
-    describe_resource( stream, "multilist2", m_multilist2, m_multilist2 && m_multilist2.size( ) > 16 );
-    describe_resource( stream, "raw1", m_raw1, m_raw1 && m_raw1->size( ) > 16 );
-    describe_resource( stream, "raw2", m_raw2, m_raw2 && m_raw2.size( ) > 16 );
-    describe_resource( stream, "refs", m_refs );
-    describe_resource( stream, "multirefs", m_multirefs );
+    describe_resource( nest_level, stream, "list1", m_list1, m_list1 && m_list1->size( ) > 16 );
+    describe_resource( nest_level, stream, "list2", m_list2, m_list2 && m_list2.size( ) > 16 );
+    describe_resource( nest_level, stream, "multilist1", m_multilist1, m_multilist1 && m_multilist1->size( ) > 16 );
+    describe_resource( nest_level, stream, "multilist2", m_multilist2, m_multilist2 && m_multilist2.size( ) > 16 );
+    describe_resource( nest_level, stream, "raw1", m_raw1, m_raw1 && m_raw1->size( ) > 16 );
+    describe_resource( nest_level, stream, "raw2", m_raw2, m_raw2 && m_raw2.size( ) > 16 );
+    describe_resource( nest_level, stream, "refs", m_refs );
+    describe_resource( nest_level, stream, "multirefs", m_multirefs );
 }

--- a/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
+++ b/flatdata-generator/tests/generators/cpp_expectations/enums/structs.h
@@ -55,7 +55,7 @@ union StructEnumI8Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -123,7 +123,7 @@ union StructEnumU8Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -191,7 +191,7 @@ union StructEnumI16Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -259,7 +259,7 @@ union StructEnumU16Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -327,7 +327,7 @@ union StructEnumI32Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -395,7 +395,7 @@ union StructEnumU32Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -463,7 +463,7 @@ union StructEnumI64Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -531,7 +531,7 @@ union StructEnumU64Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 
@@ -681,10 +681,17 @@ std::string StructEnumI8Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumI8Template< Member >::describe( ) const
+std::string StructEnumI8Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -815,10 +822,17 @@ std::string StructEnumU8Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumU8Template< Member >::describe( ) const
+std::string StructEnumU8Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -949,10 +963,17 @@ std::string StructEnumI16Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumI16Template< Member >::describe( ) const
+std::string StructEnumI16Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -1083,10 +1104,17 @@ std::string StructEnumU16Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumU16Template< Member >::describe( ) const
+std::string StructEnumU16Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -1217,10 +1245,17 @@ std::string StructEnumI32Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumI32Template< Member >::describe( ) const
+std::string StructEnumI32Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -1351,10 +1386,17 @@ std::string StructEnumU32Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumU32Template< Member >::describe( ) const
+std::string StructEnumU32Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -1485,10 +1527,17 @@ std::string StructEnumI64Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumI64Template< Member >::describe( ) const
+std::string StructEnumI64Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n
@@ -1619,10 +1668,17 @@ std::string StructEnumU64Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string StructEnumU64Template< Member >::describe( ) const
+std::string StructEnumU64Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.1
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.1
@@ -30,7 +30,7 @@ union U8Template
     explicit operator bool( ) const;
 
     std::string to_string( ) const;
-    std::string describe( ) const;
+    std::string describe( size_t unused = 0 ) const;
 
     static constexpr bool IS_OVERLAPPING_WITH_NEXT = false;
 

--- a/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
+++ b/flatdata-generator/tests/generators/cpp_expectations/structs/integers.h.2
@@ -98,10 +98,17 @@ std::string U8Template< Member >::to_string( ) const
 
 template< template < typename, int, int, int > class Member >
 inline
-std::string U8Template< Member >::describe( ) const
+std::string U8Template< Member >::describe( size_t /*unused*/ ) const
 {
     std::ostringstream ss;
-    ss << "Structure of size " << size_in_bytes( );
+    if( this->operator bool( ) )
+    {
+        ss << "Structure of size " << size_in_bytes( );
+    }
+    else
+    {
+        ss << "Uninitialized Structure " << name();
+    }
     return ss.str( );
 }
 } // namespace n


### PR DESCRIPTION
Added to template adding describe to optional resources.
Prepended a newline for readability.