### PR TITLE
Fix default initializing ArrayView for overlapping structs

### DIFF
--- a/flatdata-cpp/include/flatdata/MemoryDescriptor.h
+++ b/flatdata-cpp/include/flatdata/MemoryDescriptor.h
@@ -30,8 +30,7 @@ public:
         return m_ptr != nullptr;
     }
 
-    std::string
-    describe( size_t nest_level = 0 ) const
+    std::string describe( size_t /*nest_level*/ = 0 ) const
     {
         std::ostringstream ss;
         if ( this->operator bool( ) )

--- a/flatdata-cpp/include/flatdata/internal/ArrayView.inl
+++ b/flatdata-cpp/include/flatdata/internal/ArrayView.inl
@@ -12,7 +12,7 @@ ArrayView< T >::ArrayView( ConstStreamType data_begin, ConstStreamType data_end 
     : m_data( data_begin )
     , m_size( ( data_end - data_begin ) / T::size_in_bytes( ) )
 {
-    if ( T::IS_OVERLAPPING_WITH_NEXT )
+    if ( T::IS_OVERLAPPING_WITH_NEXT && m_size != 0 )
     {
         m_size--;
     }

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -3,7 +3,6 @@
  * See the LICENSE file in the root of this project for license details.
  */
 
-#include "test_structures.hpp"
 #include "ranges.hpp"
 
 #include <flatdata/flatdata.h>
@@ -25,6 +24,12 @@ TEST_CASE( "Reading from ArrayView", "[ArrayView]" )
     {
         REQUIRE( view[ i ].value == i );
     }
+}
+
+TEST_CASE( "Initializing overlapping ArrayView", "[ArrayView]" )
+{
+    ArrayView< TestIndexType48 > view;
+    REQUIRE( view.size( ) == 0 );
 }
 
 TEST_CASE( "Slicing ArrayView", "[ArrayView]" )

--- a/flatdata-cpp/test/ArrayViewTest.cpp
+++ b/flatdata-cpp/test/ArrayViewTest.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ranges.hpp"
+#include "test_structures.hpp"
 
 #include <flatdata/flatdata.h>
 #include "catch.hpp"


### PR DESCRIPTION
Previously this would underflow and create a view for maximum possible size, starting from nullptr.