### PR TITLE
Check structs used in explicit references

### DIFF
--- a/flatdata-generator/flatdata/generator/tree/errors.py
+++ b/flatdata-generator/flatdata/generator/tree/errors.py
@@ -100,6 +100,13 @@ class InvalidEnumValueError(FlatdataSyntaxError):
             .format(enumeration_name=enumeration_name, value=value))
 
 
+class InvalidStructInExplicitReference(FlatdataSyntaxError):
+    def __init__(self, struct, resource):
+        super().__init__(
+            "Struct '{struct}' referenced, but not appearing in resource '{resource}'"
+            .format(struct=struct, resource=resource))
+
+
 class InvalidEnumWidthError(FlatdataSyntaxError):
     def __init__(self, enumeration_name, width, provided_width):
         super().__init__(

--- a/flatdata-generator/tests/tree/test_node_tree_builder.py
+++ b/flatdata-generator/tests/tree/test_node_tree_builder.py
@@ -413,7 +413,6 @@ def test_namespace_merging_works_for_same_namespaces_with_different_symbols():
                   '.n1.n2.B', '.n1.n2.B.refN2'},
                  tree.symbols())
 
-
 def test_exceeding_field_width_results_in_an_error():
     with assert_raises(InvalidWidthError):
         _build_node_tree("""

--- a/flatdata-generator/tests/tree/test_syntax_tree_builder.py
+++ b/flatdata-generator/tests/tree/test_syntax_tree_builder.py
@@ -9,7 +9,8 @@ from nose.tools import assert_equal, assert_is_instance, assert_raises, assert_t
 
 sys.path.insert(0, "..")
 from flatdata.generator.tree.errors import MissingSymbol, InvalidRangeName, InvalidRangeReference, \
-    InvalidConstReference, InvalidConstValueReference, DuplicateInvalidValueReference
+    InvalidConstReference, InvalidConstValueReference, DuplicateInvalidValueReference, \
+    InvalidStructInExplicitReference
 from flatdata.generator.tree.builder import build_ast
 from flatdata.generator.tree.nodes.trivial import Namespace, Structure, Field, Constant, Enumeration, EnumerationValue
 from flatdata.generator.tree.nodes.archive import Archive
@@ -477,3 +478,22 @@ namespace n{
     tree.find(".n.A.@@n@C")
     tree.find(".n.A.@@m@C")
     tree.find(".n.A.@@n@m@C")
+
+def test_explicit_reference_has_to_reference_struct_used_in_resource():
+    with assert_raises(InvalidStructInExplicitReference):
+        build_ast("""
+            namespace prime {
+            struct Factor {
+                value : u32 : 32;
+            }
+            struct Number {
+                @range(factors)
+                first_factor_ref : u32;
+            }
+            
+            archive Archive {
+                @explicit_reference( Factor.value, factors )
+                numbers : vector<Number>;
+                factors : vector<Factor>;
+            }
+            } """)


### PR DESCRIPTION
Generated error messages like:
`CRITICAL - app:71 - Error reading schema: Struct 'Factor' referenced, but not appearing in resource 'numbers'`

Fixes #202