### PR TITLE
Resolve enum names for Dot diagrams

### DIFF
--- a/flatdata-generator/flatdata/generator/generators/dot.py
+++ b/flatdata-generator/flatdata/generator/generators/dot.py
@@ -19,5 +19,17 @@ class DotGenerator(BaseGenerator):
     def _populate_environment(self, env):
         env.autoescape = True
 
+        def _field_value_type(field):
+            type_name = field.type.name.replace("@@", ".").replace("@", ".")
+            namespace_name = field.parent.parent.path
+            if type_name.startswith(namespace_name):
+                type_name = type_name[len(namespace_name):]
+            if type_name.startswith("."):
+                type_name = type_name[1:]
+
+            return type_name
+
+        env.filters["field_value_type"] = _field_value_type
+
     def supported_nodes(self):
         return [Archive]

--- a/flatdata-generator/flatdata/generator/templates/dot/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/dot/structure.jinja2
@@ -11,7 +11,7 @@
     {% for field in struct.fields %}
     <tr>
         <td bgcolor="{{ styles.color_structure_member_bg }}" port="port_{{ resource.path_with() + field.path_with() }}">
-            <b><font color="{{ styles.color_structure_member_fg }}">{{ field.name }}</font></b>:<font color="{{ styles.color_structure_member_type_fg }}">{{ field.type.name }}</font>:<font color="{{ styles.color_structure_member_width_fg }}">{{ field.type.width }}</font>
+            <b><font color="{{ styles.color_structure_member_fg }}">{{ field.name }}</font></b>:<font color="{{ styles.color_structure_member_type_fg }}">{{ field | field_value_type }}</font>:<font color="{{ styles.color_structure_member_width_fg }}">{{ field.type.width }}</font>
         </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Fixes #204

Example input
```
namespace n{
enum EnumI8 : i8 : 1 {
	VALUE = 0,
}

struct StructEnumI8 {
	f : EnumI8 : 1;
	g: i16 : 1;
}

archive A {
	data : vector< StructEnumI8 >;
}
}
```

Example output:
![dot](https://user-images.githubusercontent.com/14972638/141757818-f0e170f7-4417-464e-b5a0-b39dd1bb9a0c.png)

Signed-off-by: Christian Vetter <christian.vetter@here.com>