### PR TITLE
Add possibility to retrieve min and max for Struct fields in C++

### DIFF
--- a/flatdata-cpp/include/flatdata/internal/BitHelpers.h
+++ b/flatdata-cpp/include/flatdata/internal/BitHelpers.h
@@ -80,6 +80,30 @@ struct IsSigned
     };
 };
 
+template < typename T, bool is_enum >
+struct UnderlyingTypeImpl
+{
+};
+
+template < typename T >
+struct UnderlyingTypeImpl< T, false >
+{
+    using type = T;
+};
+
+template < typename T >
+struct UnderlyingTypeImpl< T, true >
+{
+    using type = typename std::underlying_type< T >::type;
+};
+
+// Since std::underlying_type only works for enums we need to add support ourselves
+template < typename T >
+struct UnderlyingType
+{
+    using type = typename UnderlyingTypeImpl< T, std::is_enum< T >::value >::type;
+};
+
 template < typename ResultType, int num_bits, typename T >
 typename std::enable_if< IsSigned< ResultType >::value, ResultType >::type
 extend_sign( T value )

--- a/flatdata-cpp/test/WriterReaderTest.cpp
+++ b/flatdata-cpp/test/WriterReaderTest.cpp
@@ -196,6 +196,40 @@ TEST_CASE( "Range", "[Read/Write]" )
     REQUIRE( result.second == 32 );
 }
 
+TEST_CASE( "Min/Max", "[Reader]" )
+{
+    REQUIRE( Reader< uint32_t, 0, 0, 666 >::min == 0 );
+    REQUIRE( Reader< uint32_t, 0, 0, 666 >::max == 0 );
+    REQUIRE( Reader< int32_t, 0, 0, 666 >::min == 0 );
+    REQUIRE( Reader< int32_t, 0, 0, 666 >::max == 0 );
+
+    REQUIRE( Reader< uint32_t, 1, 1, 666 >::min == 0 );
+    REQUIRE( Reader< uint32_t, 1, 1, 666 >::max == 1 );
+    REQUIRE( Reader< int32_t, 1, 1, 666 >::min == -1 );
+    REQUIRE( Reader< int32_t, 1, 1, 666 >::max == 0 );
+
+    REQUIRE( Reader< uint32_t, 7, 7, 666 >::min == 0 );
+    REQUIRE( Reader< uint32_t, 7, 7, 666 >::max == 127 );
+    REQUIRE( Reader< int32_t, 7, 7, 666 >::min == -64 );
+    REQUIRE( Reader< int32_t, 7, 7, 666 >::max == 63 );
+
+    REQUIRE( Reader< uint32_t, 16, 16, 666 >::min == 0 );
+    REQUIRE( Reader< uint32_t, 16, 16, 666 >::max == 65535 );
+    REQUIRE( Reader< int32_t, 16, 16, 666 >::min == -32768 );
+    REQUIRE( Reader< int32_t, 16, 16, 666 >::max == 32767 );
+
+    REQUIRE( Reader< uint32_t, 32, 32, 666 >::min == 0 );
+    REQUIRE( Reader< uint32_t, 32, 32, 666 >::max == std::numeric_limits< uint32_t >::max( ) );
+    REQUIRE( Reader< int32_t, 32, 32, 666 >::min == std::numeric_limits< int32_t >::min( ) );
+    REQUIRE( Reader< int32_t, 32, 32, 666 >::max == std::numeric_limits< int32_t >::max( ) );
+
+    REQUIRE( Reader< bool, 16, 1, 666 >::min == false );
+    REQUIRE( Reader< bool, 16, 1, 666 >::max == true );
+
+    REQUIRE( Reader< TestEnum, 7, 7, 666 >::min == 0 );
+    REQUIRE( Reader< TestEnum, 7, 7, 666 >::max == 127 );
+}
+
 #if ( GENERATE_PYTHON_READER_TESTS )
 TEST_CASE( "Fail if python test output is enabled", "[Reader]" )
 {


### PR DESCRIPTION
Fixes #185

Min/max are lower_case for consistency's sake: bit_width already was