### PR TITLE
Fix clang warning about implicit type conversion

### DIFF
--- a/flatdata-cpp/include/flatdata/internal/Reader.h
+++ b/flatdata-cpp/include/flatdata/internal/Reader.h
@@ -44,7 +44,9 @@ struct Reader
                                      : ( typename BitsToUnsigned< num_bits >::type( 1 )
                                          << ( bit_width - std::is_signed< T >::value ) )
                                            - 1 ),
-        min = bit_width == 0 || !std::is_signed< T >::value ? 0 : -max - 1
+        min = bit_width == 0 || !std::is_signed< T >::value
+                  ? static_cast< typename UnderlyingType< T >::type >( 0 )
+                  : static_cast< typename UnderlyingType< T >::type >( -max - 1 )
     };
 
     StreamType data;


### PR DESCRIPTION
The code is actually safe without this as it is conditionally compiled, but clang does not realize this.

Signed-off-by: Christian Vetter <christian.vetter@here.com>