### PR TITLE
Upgrade memmap2 to latest version.

### DIFF
--- a/flatdata-rs/lib/Cargo.toml
+++ b/flatdata-rs/lib/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 diff = "0.1.11"
-memmap2 = "0.2.0"
+memmap2 = "0.5.7"
 tar = { version = "0.4.38", optional = true }
 walkdir = "2.2.9"
 


### PR DESCRIPTION
I PRed switching to the maintained memmap2 in https://github.com/boxdot/osmflat-rs/pull/67 . 

This just bumps the version used in flatdata for parity.