### PR TITLE
Point to flatdata-generator v0.4.6

### DIFF
--- a/flatdata-rs/lib/src/generator.rs
+++ b/flatdata-rs/lib/src/generator.rs
@@ -95,7 +95,7 @@ pub fn generate(
             path
         } else {
             eprintln!("installing flatdata-generator from PyPI");
-            PathBuf::from("flatdata-generator==0.4.5")
+            PathBuf::from("flatdata-generator==0.4.6")
         };
         let _ = Command::new(out_dir.join("bin/pip3"))
             .arg("install")


### PR DESCRIPTION
Updating the version of `flatdata-generator` (used in `fn generate`) to `0.4.6` in order to match the one set as [dependency requirement](https://github.com/heremaps/flatdata/blob/master/flatdata-py/requirements.txt#L1)