### PR TITLE
Add closing delimiter that was missing in rust generated code

### DIFF
--- a/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/rust/structure.jinja2
@@ -113,7 +113,7 @@ impl {{ struct.name }} {
         let start = flatdata_read_bytes!({{ field.type.name }}, self.data.as_ptr(), {{ field.offset }}, {{ field.type.width }});
         let end = flatdata_read_bytes!({{ field.type.name }}, self.data.as_ptr(), {{ field.offset }} + {{ struct.size_in_bytes }} * 8, {{ field.type.width }});
         {% if field.invalid_value %}
-        let check = |x| {% if field.invalid_value %}Some(x).filter(|&x| x != {{ fully_qualified_name(struct, field.invalid_value.node) }}{% else %}x{% endif %};
+        let check = |x| {% if field.invalid_value %}Some(x).filter(|&x| x != {{ fully_qualified_name(struct, field.invalid_value.node) }}){% else %}x{% endif %};
         check(start)..check(end)
         {% else %}
         start..end


### PR DESCRIPTION
# Why this change is required?

When we try adding index range in flatdata like below example and generate the rust code, the generated rust code is invalid.

```
struct Node {
    @range(edges_range)
    @optional( NO_EDGES_REF )
    first_edge_ref : u32;
}
```

When we use the generated code, compilation fails with below reason:

```
    |
483 |     pub fn edges_range(&self) -> std::ops::Range<Option<u32>> {
    |                                                               - closing delimiter possibly meant for this
...
486 |         let check = |x| Some(x).filter(|&x| x != super::test::NO_EDGES_REF;
    |                                       ^ unclosed delimiter
487 |         check(start)..check(end)
488 |     }
    |     ^ mismatched closing delimiter
```

# What this change does?

- Add closing delimiter to jinja template