### PR TITLE
Report errors when trying to using optional ranges

### DIFF
--- a/flatdata-generator/flatdata/generator/tree/builder.py
+++ b/flatdata-generator/flatdata/generator/tree/builder.py
@@ -10,7 +10,7 @@ from flatdata.generator.grammar import flatdata_grammar
 from flatdata.generator.tree.errors import (
     InvalidEnumWidthError, InvalidRangeName, InvalidRangeReference,
     InvalidConstReference, InvalidConstValueReference, DuplicateInvalidValueReference,
-    InvalidStructInExplicitReference)
+    InvalidStructInExplicitReference, OptionalRange)
 from flatdata.generator.tree.nodes.explicit_reference import ExplicitReference
 from flatdata.generator.tree.nodes.archive import Archive
 from flatdata.generator.tree.nodes.node import Node
@@ -181,6 +181,9 @@ def _check_ranges(root):
         for sibling in field.parent.fields:
             if sibling.name == name:
                 raise InvalidRangeName(name)
+        # Also check that the range is not optional
+        if field.invalid_value:
+            raise OptionalRange(name)
 
     # Now check that structs with ranges are only used in vectors
     for reference in root.iterate(StructureReference):

--- a/flatdata-generator/flatdata/generator/tree/errors.py
+++ b/flatdata-generator/flatdata/generator/tree/errors.py
@@ -149,3 +149,9 @@ class InvalidRangeReference(FlatdataSyntaxError):
         super().__init__(
             "Structs with @range can only be used in vectors: {name}"
             .format(name=name))
+
+class OptionalRange(FlatdataSyntaxError):
+    def __init__(self, name):
+        super().__init__(
+            "@range cannot be combined with @optional, store empty ranges instead: {name}"
+            .format(name=name))

--- a/flatdata-generator/pyproject.toml
+++ b/flatdata-generator/pyproject.toml
@@ -7,7 +7,6 @@ name = "flatdata-generator"
 version = "0.4.6"
 description = "Generate source code for C++, Rust, Go or Python from a Flatdata schema file"
 readme = "README.md"
-license = ""
 authors = [
     { name = "Flatdata Developers" },
 ]

--- a/flatdata-generator/tests/tree/test_syntax_tree_builder.py
+++ b/flatdata-generator/tests/tree/test_syntax_tree_builder.py
@@ -10,7 +10,7 @@ from nose.tools import assert_equal, assert_is_instance, assert_raises, assert_t
 sys.path.insert(0, "..")
 from flatdata.generator.tree.errors import MissingSymbol, InvalidRangeName, InvalidRangeReference, \
     InvalidConstReference, InvalidConstValueReference, DuplicateInvalidValueReference, \
-    InvalidStructInExplicitReference
+    InvalidStructInExplicitReference, OptionalRange
 from flatdata.generator.tree.builder import build_ast
 from flatdata.generator.tree.nodes.trivial import Namespace, Structure, Field, Constant, Enumeration, EnumerationValue
 from flatdata.generator.tree.nodes.archive import Archive
@@ -20,8 +20,6 @@ from flatdata.generator.tree.nodes.resources import Vector, Multivector, RawData
 from flatdata.generator.tree.nodes.references import ResourceReference, StructureReference, \
     FieldReference, ArchiveReference, BuiltinStructureReference, ConstantValueReference, \
     EnumerationReference, InvalidValueReference
-
-
 
 def test_validating_archive_with_no_structure_defined_raises_missing_symbol_error():
     def __test(resource_type):
@@ -102,6 +100,17 @@ def test_range_cannot_be_used_in_struct_resource():
             }
             }
             """)
+
+def test_optional_range():
+    with assert_raises(OptionalRange):
+        build_ast("""namespace foo{
+            const u32 NO_EDGES_REF = 200;
+            struct Node {
+                @range(edges_range)
+                @optional( NO_EDGES_REF )
+                first_edge_ref : u32;
+            }
+            }""")
 
 def test_ranges_can_be_used_in_normally():
     build_ast("""namespace foo{

--- a/flatdata-py/pyproject.toml
+++ b/flatdata-py/pyproject.toml
@@ -7,7 +7,6 @@ name = "flatdata-py"
 version = "0.4.7"
 description = "Python 3 implementation of Flatdata"
 readme = "README.md"
-license = ""
 authors = [
     { name = "Flatdata Developers" },
 ]


### PR DESCRIPTION
`@range` attribute cannot be combined with @optional: Users should store empty ranges instead (see #249).

This change make sure to report an error

```
14:30:42 - CRITICAL - app:71 - Error reading schema: @range cannot be combined with @optional, store empty ranges instead: edges_range 
```

For this schema:

```
namespace foo{
const u32 NO_EDGES_REF = 200;
struct Node {
    @range(edges_range)
    @optional( NO_EDGES_REF )
    first_edge_ref : u32;
}
}
```