### PR TITLE
Support proper numpy integration for ~100x performance boost

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Run tests
         run: |
           cd flatdata-py
-          uv run --with pytest --with ../flatdata-generator pytest -v
-          pip install .
-          flatdata-inspector --help
+          uv venv
+          uv pip install ../flatdata-generator
+          uv pip install ".[inspector]" pytest
+          .venv/bin/pytest -v
+          .venv/bin/flatdata-inspector --help
 

--- a/flatdata-generator/flatdata/generator/templates/py/python.jinja2
+++ b/flatdata-generator/flatdata/generator/templates/py/python.jinja2
@@ -10,6 +10,7 @@ import flatdata.lib as flatdata
 {{ struct.doc|to_python_doc}}
 class {{ tree.namespace_path(struct, "_") }}_{{ struct.name }}(flatdata.structure.Structure):
     """{{ struct.doc|safe_py_string_line }}"""
+    __slots__ = ()
     _SCHEMA = """{{ tree.schema(struct) }}"""
     _NAME = "{{ tree.namespace_path(struct, "_") }}_{{ struct.name }}"
     _SIZE_IN_BITS = {{ struct.size_in_bits }}

--- a/flatdata-generator/pyproject.toml
+++ b/flatdata-generator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flatdata-generator"
-version = "0.4.10"
+version = "0.4.11"
 description = "Generate source code for C++, Rust, Go or Python from a Flatdata schema file"
 readme = "README.md"
 authors = [

--- a/flatdata-generator/tests/generators/py_expectations/archives/multivector.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/multivector.py
@@ -1,5 +1,6 @@
 class n_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct S
 {
@@ -20,6 +21,7 @@ struct S
 
 class n_T(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct T
 {
@@ -40,6 +42,7 @@ struct T
 #  Builtin type to for MultiVector index 
 class n__builtin_multivector_IndexType8(flatdata.structure.Structure):
     """/** Builtin type to for MultiVector index */"""
+    __slots__ = ()
     _SCHEMA = """"""
     _NAME = "n__builtin_multivector_IndexType8"
     _SIZE_IN_BITS = 8
@@ -53,6 +56,7 @@ class n__builtin_multivector_IndexType8(flatdata.structure.Structure):
 #  Builtin type to for MultiVector index 
 class n__builtin_multivector_IndexType16(flatdata.structure.Structure):
     """/** Builtin type to for MultiVector index */"""
+    __slots__ = ()
     _SCHEMA = """"""
     _NAME = "n__builtin_multivector_IndexType16"
     _SIZE_IN_BITS = 16
@@ -66,6 +70,7 @@ class n__builtin_multivector_IndexType16(flatdata.structure.Structure):
 #  Builtin type to for MultiVector index 
 class n__builtin_multivector_IndexType64(flatdata.structure.Structure):
     """/** Builtin type to for MultiVector index */"""
+    __slots__ = ()
     _SCHEMA = """"""
     _NAME = "n__builtin_multivector_IndexType64"
     _SIZE_IN_BITS = 64

--- a/flatdata-generator/tests/generators/py_expectations/archives/namespaces.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/namespaces.py
@@ -1,5 +1,6 @@
 class n_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct S
 {
@@ -92,6 +93,7 @@ archive X
 
 class m_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace m {
 struct S
 {
@@ -184,6 +186,7 @@ archive X
 #  Builtin type to for MultiVector index 
 class a__builtin_multivector_IndexType32(flatdata.structure.Structure):
     """/** Builtin type to for MultiVector index */"""
+    __slots__ = ()
     _SCHEMA = """"""
     _NAME = "a__builtin_multivector_IndexType32"
     _SIZE_IN_BITS = 32

--- a/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/ranges.py
@@ -1,5 +1,6 @@
 class n_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct S
 {

--- a/flatdata-generator/tests/generators/py_expectations/archives/struct.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/struct.py
@@ -1,5 +1,6 @@
 class n_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct S
 {

--- a/flatdata-generator/tests/generators/py_expectations/archives/vector.py
+++ b/flatdata-generator/tests/generators/py_expectations/archives/vector.py
@@ -1,5 +1,6 @@
 class n_S(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct S
 {

--- a/flatdata-generator/tests/generators/py_expectations/structs/comments.py.1
+++ b/flatdata-generator/tests/generators/py_expectations/structs/comments.py.1
@@ -1,4 +1,5 @@
 #  This is a comment about Foo
 class n_Foo(flatdata.structure.Structure):
     """// This is a comment about Foo"""
+    __slots__ = ()
     _SCHEMA = """namespace n {

--- a/flatdata-generator/tests/generators/py_expectations/structs/comments.py.2
+++ b/flatdata-generator/tests/generators/py_expectations/structs/comments.py.2
@@ -1,3 +1,4 @@
 #  This is a comment about Foo
 class n_Foo(flatdata.structure.Structure):
     """// This is a comment about Foo"""
+    __slots__ = ()

--- a/flatdata-generator/tests/generators/py_expectations/structs/integers.py
+++ b/flatdata-generator/tests/generators/py_expectations/structs/integers.py
@@ -12,6 +12,7 @@ import flatdata.lib as flatdata
 
 class n_U8(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U8
 {
@@ -32,6 +33,7 @@ struct U8
 
 class n_I8(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I8
 {
@@ -52,6 +54,7 @@ struct I8
 
 class n_U16(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U16
 {
@@ -72,6 +75,7 @@ struct U16
 
 class n_I16(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I16
 {
@@ -92,6 +96,7 @@ struct I16
 
 class n_U32(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U32
 {
@@ -112,6 +117,7 @@ struct U32
 
 class n_I32(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I32
 {
@@ -132,6 +138,7 @@ struct I32
 
 class n_U64(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U64
 {
@@ -152,6 +159,7 @@ struct U64
 
 class n_I64(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I64
 {

--- a/flatdata-generator/tests/generators/py_expectations/structs/namespaces.py
+++ b/flatdata-generator/tests/generators/py_expectations/structs/namespaces.py
@@ -1,5 +1,6 @@
 class n_Foo(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct Foo
 {
@@ -20,6 +21,7 @@ struct Foo
 
 class m_Foo(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace m {
 struct Foo
 {

--- a/flatdata-generator/tests/generators/py_expectations/structs/unaligned.py
+++ b/flatdata-generator/tests/generators/py_expectations/structs/unaligned.py
@@ -1,5 +1,6 @@
 class n_U8(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U8
 {
@@ -23,6 +24,7 @@ struct U8
 
 class n_I8(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I8
 {
@@ -46,6 +48,7 @@ struct I8
 
 class n_U16(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U16
 {
@@ -69,6 +72,7 @@ struct U16
 
 class n_I16(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I16
 {
@@ -92,6 +96,7 @@ struct I16
 
 class n_U32(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U32
 {
@@ -115,6 +120,7 @@ struct U32
 
 class n_I32(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I32
 {
@@ -138,6 +144,7 @@ struct I32
 
 class n_U64(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct U64
 {
@@ -161,6 +168,7 @@ struct U64
 
 class n_I64(flatdata.structure.Structure):
     """"""
+    __slots__ = ()
     _SCHEMA = """namespace n {
 struct I64
 {

--- a/flatdata-py/README.md
+++ b/flatdata-py/README.md
@@ -18,6 +18,37 @@ Once you have [created a flatdata schema file](../README.md#creating-a-schema), 
 flatdata-generator --gen py --schema locations.flatdata --output-file locations.py
 ```
 
+## Performance tips
+
+`flatdata-py` supports two data access patterns with very different performance characteristics on large archives.
+
+Iterating over a vector yields one Python object per element. Each field access unpacks bits from the underlying memory-mapped data. This is fine for accessing individual elements or small ranges, but has significant per-element overhead for bulk operations:
+
+```python
+count = sum(1 for x in archive.links if x.speed_limit > 100)
+```
+
+For bulk operations, use the vectorized access methods that read fields directly into NumPy arrays:
+
+```python
+# single column access, returns a pandas DataFrame
+df = archive.links.speed_limit
+count = len(df[df['speed_limit'] > 100])
+
+# full NumPy structured array with all fields
+arr = archive.links.to_numpy()
+count = int(np.sum(arr['speed_limit'] > 100))
+
+# slices work too
+arr = archive.links[1000:2000].to_numpy()
+df = archive.links[::10].to_data_frame()
+```
+
+* Use `vector.field_name` (column access) when you only need one or a few fields.
+* Use `vector.to_numpy()` or `vector.to_data_frame()` when you need all fields at once.
+* Use `vector[i].field` for random access to individual elements.
+* The underlying data is memory-mapped; the OS pages it from disk on demand. Vectorized results are materialized as NumPy arrays in RAM.
+
 ## Using the inspector
 
 `flatdata-py` comes with a handy tool called the `flatdata-inspector` to inspect the contents of an archive:

--- a/flatdata-py/flatdata/lib/archive.py
+++ b/flatdata-py/flatdata/lib/archive.py
@@ -39,9 +39,9 @@ class Archive:
             self.__getattr__(name)
 
     def __getattr__(self, name):
-        if name not in list(self._RESOURCES.keys()):
+        if name not in self._RESOURCES:
             raise AttributeError("Resource %s not defined in archive." % name)
-        if name not in list(self._loaded_resources.keys()):
+        if name not in self._loaded_resources:
             self._loaded_resources[name] = self._open_resource(name)
         return self._loaded_resources[name]
 

--- a/flatdata-py/flatdata/lib/data_access.py
+++ b/flatdata-py/flatdata/lib/data_access.py
@@ -22,9 +22,7 @@ def read_value(data, offset_bits, num_bits, is_signed):
         remainder = data[offset_bytes + total_bytes]
         result |= remainder << (total_bytes * 8 - offset_extra_bits)
 
-    if num_bits < 64:
-        result = result & ((1 << num_bits) - 1)
-    elif offset_extra_bits > 0:
+    if num_bits < 64 or offset_extra_bits > 0:
         result = result & ((1 << num_bits) - 1)
 
     if not is_signed:

--- a/flatdata-py/flatdata/lib/data_access.py
+++ b/flatdata-py/flatdata/lib/data_access.py
@@ -3,6 +3,8 @@
  See the LICENSE file in the root of this project for license details.
 '''
 
+import numpy as np
+
 # Sign bits cache for the value reading.
 _SIGN_BITS = [0] + [(1 << (bits - 1)) for bits in range(1, 65)]
 
@@ -62,3 +64,32 @@ def write_value(data, offset_bits, num_bits, is_signed, value):
         surrounding_bits = data[offset_bytes + byte_idx] & ~((1 << offset_bits) - 1)
         data[offset_bytes + byte_idx] = value_in_little_endian[byte_idx] & ((1 << (8 - (bits_written % 8))) - 1)
         data[offset_bytes + byte_idx] |= surrounding_bits
+
+
+def read_field_vectorized(raw_bytes_2d, field_offset_bits, field_width_bits, is_signed):
+    """Read a bit-packed field from all elements at once, returning a numpy array.
+
+    :param raw_bytes_2d: numpy uint8 array shaped (num_elements, struct_size_bytes)
+    :param field_offset_bits: bit offset of the field within each element
+    :param field_width_bits: width of the field in bits (max 64)
+    :param is_signed: whether to sign-extend the result
+    :return: numpy array of field values
+    """
+    byte_start = field_offset_bits // 8
+    bit_shift = field_offset_bits % 8
+    bytes_needed = (bit_shift + field_width_bits + 7) // 8
+
+    result = np.zeros(raw_bytes_2d.shape[0], dtype=np.uint64)
+    for b in range(bytes_needed):
+        result |= raw_bytes_2d[:, byte_start + b].astype(np.uint64) << np.uint64(b * 8)
+    result >>= np.uint64(bit_shift)
+
+    if field_width_bits < 64:
+        result &= np.uint64((1 << field_width_bits) - 1)
+
+    if is_signed:
+        sign_bit = np.uint64(1 << (field_width_bits - 1))
+        signed = result.astype(np.int64) - np.int64(1 << field_width_bits)
+        result = np.where(result & sign_bit, signed, result.astype(np.int64))
+
+    return result

--- a/flatdata-py/flatdata/lib/data_access.py
+++ b/flatdata-py/flatdata/lib/data_access.py
@@ -24,6 +24,8 @@ def read_value(data, offset_bits, num_bits, is_signed):
 
     if num_bits < 64:
         result = result & ((1 << num_bits) - 1)
+    elif offset_extra_bits > 0:
+        result = result & ((1 << num_bits) - 1)
 
     if not is_signed:
         return result
@@ -75,21 +77,38 @@ def read_field_vectorized(raw_bytes_2d, field_offset_bits, field_width_bits, is_
     :param is_signed: whether to sign-extend the result
     :return: numpy array of field values
     """
+    if field_width_bits == 1:
+        byte_idx = field_offset_bits // 8
+        bit_idx = field_offset_bits % 8
+        return ((raw_bytes_2d[:, byte_idx].astype(np.uint64) >> np.uint64(bit_idx)) &
+                np.uint64(1))
+
     byte_start = field_offset_bits // 8
     bit_shift = field_offset_bits % 8
     bytes_needed = (bit_shift + field_width_bits + 7) // 8
 
+    # Use Python int arithmetic for the shift to avoid numpy overflow,
+    # then broadcast back to the array.
     result = np.zeros(raw_bytes_2d.shape[0], dtype=np.uint64)
-    for b in range(bytes_needed):
+    for b in range(min(bytes_needed, 8)):
         result |= raw_bytes_2d[:, byte_start + b].astype(np.uint64) << np.uint64(b * 8)
     result >>= np.uint64(bit_shift)
+
+    # If the field spans more than 8 bytes (unaligned 64-bit field), merge the extra byte.
+    bits_so_far = 8 * min(bytes_needed, 8) - bit_shift
+    if bits_so_far < field_width_bits and bytes_needed > 8:
+        extra = raw_bytes_2d[:, byte_start + 8].astype(np.uint64)
+        result |= extra << np.uint64(bits_so_far)
 
     if field_width_bits < 64:
         result &= np.uint64((1 << field_width_bits) - 1)
 
     if is_signed:
+        if field_width_bits == 64:
+            return result.view(np.int64)
         sign_bit = np.uint64(1 << (field_width_bits - 1))
-        signed = result.astype(np.int64) - np.int64(1 << field_width_bits)
+        offset = -(1 << field_width_bits)
+        signed = result.astype(np.int64) + np.int64(offset)
         result = np.where(result & sign_bit, signed, result.astype(np.int64))
 
     return result

--- a/flatdata-py/flatdata/lib/resources.py
+++ b/flatdata-py/flatdata/lib/resources.py
@@ -76,7 +76,6 @@ class _VectorSlice:
 
     def to_numpy(self, limit=None):
         raw_2d = self._sequence._as_numpy_2d()
-        indices = self._slice.indices(len(self._sequence))
         sliced = raw_2d[self._slice]
         if limit is not None:
             sliced = sliced[:limit]
@@ -98,8 +97,11 @@ class _VectorSlice:
             yield self._sequence[i]
 
     def __getattr__(self, name):
+        try:
+            field = self._sequence._element_type._FIELDS[name]
+        except KeyError:
+            raise AttributeError("Field %s not found in structure" % name)
         raw_2d = self._sequence._as_numpy_2d()[self._slice]
-        field = self._sequence._element_type._FIELDS[name]
         values = read_field_vectorized(raw_2d, field.offset, field.width, field.is_signed)
         return pd.DataFrame(data=values, columns=[name])
 
@@ -148,8 +150,11 @@ class Vector(ResourceBase):
             yield element_type(mem, SIZE_OFFSET_IN_BYTES + size_bytes * i)
 
     def __getattr__(self, name):
+        try:
+            field = self._element_type._FIELDS[name]
+        except KeyError:
+            raise AttributeError("Field %s not found in structure" % name)
         raw_2d = self._as_numpy_2d()
-        field = self._element_type._FIELDS[name]
         values = read_field_vectorized(raw_2d, field.offset, field.width, field.is_signed)
         return pd.DataFrame(data=values, columns=[name])
 

--- a/flatdata-py/flatdata/lib/resources.py
+++ b/flatdata-py/flatdata/lib/resources.py
@@ -8,7 +8,7 @@ import json
 import pandas as pd
 import numpy as np
 
-from .data_access import read_value
+from .data_access import read_value, read_field_vectorized
 from .errors import CorruptResourceError
 
 SIZE_OFFSET_IN_BITS = 64
@@ -24,6 +24,7 @@ class ResourceBase:
         self._element_type = element_type
         self._element_types = [element_type]
         self._type_size_in_bytes = self._element_type._SIZE_IN_BYTES if self._element_type else 1
+        self._raw_numpy_2d = None
 
     def size_in_bytes(self):
         return len(self._mem)
@@ -34,6 +35,20 @@ class ResourceBase:
     def _get_item(self, index):
         offset = self._item_offset(index)
         return self._element_type(self._mem, offset)
+
+    def _as_numpy_2d(self):
+        """Return the raw data as a 2D numpy uint8 array of shape (n, struct_size).
+        Zero-copy via np.frombuffer on the mmap'd memory. Cached after first call.
+        """
+        if self._raw_numpy_2d is None:
+            n = len(self)
+            struct_size = self._type_size_in_bytes
+            raw = np.frombuffer(
+                self._mem[SIZE_OFFSET_IN_BYTES:SIZE_OFFSET_IN_BYTES + n * struct_size],
+                dtype=np.uint8,
+            )
+            self._raw_numpy_2d = raw.reshape(n, struct_size)
+        return self._raw_numpy_2d
 
     def _repr_attributes(self):
         return {
@@ -60,14 +75,19 @@ class _VectorSlice:
         self._sequence = sequence
 
     def to_numpy(self, limit=None):
+        raw_2d = self._sequence._as_numpy_2d()
         indices = self._slice.indices(len(self._sequence))
-        num_items = len(range(*indices)) if not limit else limit
-        result = np.empty(
-            shape=num_items,
-            dtype=self._sequence._element_type.dtype()
-        )
-        for index, item in enumerate(self):
-            result[index] = item.as_tuple()
+        sliced = raw_2d[self._slice]
+        if limit is not None:
+            sliced = sliced[:limit]
+
+        fields = self._sequence._element_type._FIELDS
+        dtype = self._sequence._element_type.dtype()
+        result = np.empty(sliced.shape[0], dtype=dtype)
+        for name, field in fields.items():
+            result[name] = read_field_vectorized(
+                sliced, field.offset, field.width, field.is_signed
+            )
         return result
 
     def to_data_frame(self, limit=None):
@@ -78,7 +98,10 @@ class _VectorSlice:
             yield self._sequence[i]
 
     def __getattr__(self, name):
-        return pd.DataFrame(data=[[getattr(item, name)] for item in self], columns=[name])
+        raw_2d = self._sequence._as_numpy_2d()[self._slice]
+        field = self._sequence._element_type._FIELDS[name]
+        values = read_field_vectorized(raw_2d, field.offset, field.width, field.is_signed)
+        return pd.DataFrame(data=values, columns=[name])
 
     def __repr__(self):
         return "Displaying first 100 records:\n" + self.to_data_frame(limit=100).__repr__()
@@ -92,8 +115,20 @@ class Vector(ResourceBase):
         assert rem == 0, "Malformed vector"
         self._size = size
 
+    def to_numpy(self):
+        """Convert entire vector to a numpy structured array (vectorized)."""
+        raw_2d = self._as_numpy_2d()
+        fields = self._element_type._FIELDS
+        dtype = self._element_type.dtype()
+        result = np.empty(self._size, dtype=dtype)
+        for name, field in fields.items():
+            result[name] = read_field_vectorized(
+                raw_2d, field.offset, field.width, field.is_signed
+            )
+        return result
+
     def to_data_frame(self):
-        return self[:].to_data_frame()
+        return pd.DataFrame(data=self.to_numpy())
 
     def __getitem__(self, index):
         if isinstance(index, slice):
@@ -106,11 +141,17 @@ class Vector(ResourceBase):
         return self._get_item(index)
 
     def __iter__(self):
-        for i in range(len(self)):
-            yield self._get_item(i)
+        mem = self._mem
+        element_type = self._element_type
+        size_bytes = self._type_size_in_bytes
+        for i in range(self._size):
+            yield element_type(mem, SIZE_OFFSET_IN_BYTES + size_bytes * i)
 
     def __getattr__(self, name):
-        return pd.DataFrame(data=[[getattr(item, name)] for item in self], columns=[name])
+        raw_2d = self._as_numpy_2d()
+        field = self._element_type._FIELDS[name]
+        values = read_field_vectorized(raw_2d, field.offset, field.width, field.is_signed)
+        return pd.DataFrame(data=values, columns=[name])
 
     def __len__(self):
         return self._size

--- a/flatdata-py/flatdata/lib/structure.py
+++ b/flatdata-py/flatdata/lib/structure.py
@@ -9,6 +9,8 @@ FieldSignature = namedtuple(
 
 
 class Structure:
+    __slots__ = ('_mem', '_pos')
+
     def __init__(self, mem, pos):
         self._mem = mem
         self._pos = pos

--- a/flatdata-py/pyproject.toml
+++ b/flatdata-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flatdata-py"
-version = "0.4.10"
+version = "0.4.11"
 description = "Python 3 implementation of Flatdata"
 readme = "README.md"
 authors = [

--- a/flatdata-py/pyproject.toml
+++ b/flatdata-py/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "flatdata-generator==0.4.10",
+    "flatdata-generator==0.4.11",
     "numpy",
     "pandas",
 ]

--- a/flatdata-py/tests/test_data_access.py
+++ b/flatdata-py/tests/test_data_access.py
@@ -1124,6 +1124,25 @@ def test_reader():
     _test_reader(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 3, 2, True, 0)
 
 
+def test_reader_unaligned_64bit():
+    """read_value must return at most 64 bits for a 64-bit field at a non-byte-aligned offset."""
+    data = b"\xff" * 9
+    # 64 bits starting at bit 1, all set → 0xFFFFFFFFFFFFFFFF
+    result = read_value(data, 1, 64, False)
+    assert result == 0xFFFFFFFFFFFFFFFF, \
+        f"Expected 0xFFFFFFFFFFFFFFFF, got {result:#x} ({result.bit_length()} bits)"
+
+    # Signed: all 1s → -1
+    result_signed = read_value(data, 1, 64, True)
+    assert result_signed == -1
+
+    # Other non-byte-aligned offsets
+    for offset in range(1, 8):
+        result = read_value(data, offset, 64, False)
+        assert result == 0xFFFFFFFFFFFFFFFF, \
+            f"offset={offset}: expected 0xFFFFFFFFFFFFFFFF, got {result:#x}"
+
+
 def test_writer():
     """
     Following tests were generated from C++ counterparts. Reasoning: python implementation lacks

--- a/flatdata-py/tests/test_vectorized_access.py
+++ b/flatdata-py/tests/test_vectorized_access.py
@@ -1,0 +1,232 @@
+"""Tests for vectorized numpy access paths."""
+
+import numpy as np
+import pytest
+
+from flatdata.generator.engine import Engine
+from flatdata.lib.data_access import read_field_vectorized
+from common import (
+    DictResourceStorage,
+    ARCHIVE_SIGNATURE_PAYLOAD,
+    VECTOR_TEST_SCHEMA,
+    RESOURCE_VECTOR_PAYLOAD,
+)
+
+
+def _make_vector_archive():
+    """Create a test archive with a vector of SignedStructs."""
+    module = Engine(VECTOR_TEST_SCHEMA).render_python_module()
+    valid_data = {
+        "Archive.archive": ARCHIVE_SIGNATURE_PAYLOAD,
+        "Archive.archive.schema": module.backward_compatibility_Archive.schema().encode(),
+        "resource": RESOURCE_VECTOR_PAYLOAD,
+        "resource.schema": module.backward_compatibility_Archive.resource_schema('resource').encode()
+    }
+    archive = module.backward_compatibility_Archive(DictResourceStorage(valid_data))
+    return archive, module
+
+
+class TestReadFieldVectorized:
+    """Tests for the read_field_vectorized function."""
+
+    def test_all_fields_match_element_access(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        raw_2d = vector._as_numpy_2d()
+
+        from flatdata.lib.data_access import read_field_vectorized
+
+        for name, field in vector._element_type._FIELDS.items():
+            values = read_field_vectorized(
+                raw_2d, field.offset, field.width, field.is_signed
+            )
+            for i in range(len(vector)):
+                expected = getattr(vector[i], name)
+                actual = int(values[i])
+                assert expected == actual, \
+                    f"Mismatch in {name}[{i}]: expected={expected}, actual={actual}"
+
+    def test_signed_fields_read_correctly(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        raw_2d = vector._as_numpy_2d()
+
+        from flatdata.lib.data_access import read_field_vectorized
+
+        # Field 'a' is i16:5 (signed, 5 bits), expected value: -1
+        field_a = vector._element_type._FIELDS['a']
+        values_a = read_field_vectorized(raw_2d, field_a.offset, field_a.width, field_a.is_signed)
+        assert int(values_a[0]) == -1
+        assert int(values_a[1]) == -1
+
+        # Field 'c' is i32:7 (signed, 7 bits), expected value: -0x28 = -40
+        field_c = vector._element_type._FIELDS['c']
+        values_c = read_field_vectorized(raw_2d, field_c.offset, field_c.width, field_c.is_signed)
+        assert int(values_c[0]) == -0x28
+        assert int(values_c[1]) == -0x28
+
+
+class TestVectorToNumpy:
+    """Tests for vectorized Vector.to_numpy()."""
+
+    def test_to_numpy_matches_element_access(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        arr = vector.to_numpy()
+
+        assert len(arr) == len(vector)
+        for name in vector._element_type._FIELDS:
+            for i in range(len(vector)):
+                expected = getattr(vector[i], name)
+                actual = int(arr[name][i])
+                assert expected == actual
+
+    def test_to_numpy_dtype(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        arr = vector.to_numpy()
+        assert arr.dtype == np.dtype(vector._element_type.dtype())
+
+    def test_to_data_frame(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        df = vector.to_data_frame()
+        assert len(df) == len(vector)
+        assert list(df.columns) == list(vector._element_type._FIELDS.keys())
+
+
+class TestVectorSliceToNumpy:
+    """Tests for vectorized _VectorSlice.to_numpy()."""
+
+    def test_slice_to_numpy(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        s = vector[0:1]
+        arr = s.to_numpy()
+
+        assert len(arr) == 1
+        for name in vector._element_type._FIELDS:
+            expected = getattr(vector[0], name)
+            actual = int(arr[name][0])
+            assert expected == actual
+
+    def test_slice_to_data_frame(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        df = vector[0:2].to_data_frame()
+        assert len(df) == 2
+
+
+class TestVectorColumnAccess:
+    """Tests for vectorized Vector.__getattr__ column access."""
+
+    def test_column_access_returns_dataframe(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        df = vector.a
+        assert len(df) == len(vector)
+        assert 'a' in df.columns
+
+    def test_column_values_match(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        df = vector.b
+        for i in range(len(vector)):
+            expected = getattr(vector[i], 'b')
+            actual = int(df['b'].iloc[i])
+            assert expected == actual
+
+
+class TestNumpyCache:
+    """Tests for the _as_numpy_2d() cache."""
+
+    def test_cache_returns_same_object(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        arr1 = vector._as_numpy_2d()
+        arr2 = vector._as_numpy_2d()
+        assert arr1 is arr2
+
+    def test_shape(self):
+        archive, module = _make_vector_archive()
+        vector = archive.resource
+        arr = vector._as_numpy_2d()
+        assert arr.shape == (len(vector), vector._element_type._SIZE_IN_BYTES)
+        assert arr.dtype == np.uint8
+
+
+class TestStructureSlots:
+    """Tests that Structure uses __slots__."""
+
+    def test_has_slots(self):
+        from flatdata.lib.structure import Structure
+        assert hasattr(Structure, '__slots__')
+        assert '_mem' in Structure.__slots__
+        assert '_pos' in Structure.__slots__
+
+
+class TestReadFieldVectorizedEdgeCases:
+    """Tests for boundary conditions in vectorized field reading."""
+
+    def test_1bit_unsigned(self):
+        raw = np.array([[0x01], [0x00], [0x03]], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 1, False)
+        assert list(result) == [1, 0, 1]
+
+    def test_1bit_signed_matches_scalar(self):
+        """1-bit signed fields should return 0 or 1, matching read_value behavior."""
+        from flatdata.lib.data_access import read_value
+        raw = np.array([[0x01], [0x00]], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 1, True)
+        assert int(result[0]) == read_value(b'\x01', 0, 1, True)
+        assert int(result[1]) == read_value(b'\x00', 0, 1, True)
+
+    def test_64bit_unsigned(self):
+        raw = np.array([[0xFF] * 8], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 64, False)
+        assert int(result[0]) == 0xFFFFFFFFFFFFFFFF
+
+    def test_64bit_signed_negative(self):
+        raw = np.array([[0xFF] * 8], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 64, True)
+        assert int(result[0]) == -1
+
+    def test_64bit_signed_positive(self):
+        raw = np.array([[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 64, True)
+        assert int(result[0]) == 1
+
+    def test_63bit_signed(self):
+        raw = np.array([[0xFF] * 8], dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 63, True)
+        assert int(result[0]) == -1
+
+    def test_unaligned_large_field(self):
+        """Fields where offset%8 + width > 64 require extra byte merge."""
+        raw = np.array([[0xFF] * 9], dtype=np.uint8)
+        # 64 bits starting at bit 1, all set → should be 0xFFFFFFFFFFFFFFFF
+        actual = int(read_field_vectorized(raw, 1, 64, False)[0])
+        assert actual == 0xFFFFFFFFFFFFFFFF
+
+    def test_empty_vector(self):
+        raw = np.zeros((0, 8), dtype=np.uint8)
+        result = read_field_vectorized(raw, 0, 32, False)
+        assert len(result) == 0
+
+
+class TestAttributeErrorContract:
+    """Vector/slice __getattr__ must raise AttributeError for unknown fields."""
+
+    def test_vector_unknown_field_raises_attribute_error(self):
+        archive, _ = _make_vector_archive()
+        with pytest.raises(AttributeError):
+            archive.resource.nonexistent_field
+
+    def test_vector_hasattr_returns_false(self):
+        archive, _ = _make_vector_archive()
+        assert not hasattr(archive.resource, "nonexistent_field")
+
+    def test_slice_unknown_field_raises_attribute_error(self):
+        archive, _ = _make_vector_archive()
+        with pytest.raises(AttributeError):
+            archive.resource[0:1].nonexistent_field


### PR DESCRIPTION
# flatdata-py performance: vectorized access and scalar optimization

## What

Adds NumPy-based vectorized field access to flatdata-py and optimizes the scalar (element-by-element) read path. Also fixes a pre-existing bug in `read_value()` for unaligned 64-bit fields.

## Changes

### Vectorized access (`data_access.py`, `resources.py`)

- `read_field_vectorized()`: reads a bit-packed field from all vector elements at once via NumPy, returning an `ndarray`. Zero-copy over the mmap'd buffer.
- `Vector.__getattr__("field")` returns a DataFrame column for the field.
- `Vector.to_numpy()` / `to_data_frame()` return all fields at once.
- `_VectorSlice` gets the same vectorized methods.
- Results are cached per vector instance via `_as_numpy_2d()`.

### Pre-computed field readers (`data_access.py`, `structure.py`)

- `make_field_reader(offset, width, signed)` builds a specialized closure with all constants (byte offset, bit shift, mask, sign handling) pre-computed. Six variants cover the cross-product of field types.
- `Structure.__init_subclass__` builds a `_READERS` dict once per class.
- `__getattr__`, `as_dict`, `as_list`, `as_tuple`, `as_nparray` all use `_READERS`.
- `read_value()` is preserved as a thin wrapper around `make_field_reader` for one-off reads.

### Bug fix (`data_access.py`)

- `read_value()` for 64-bit fields at non-byte-aligned offsets could return values wider than 64 bits (Python arbitrary-precision ints). The bit mask was only applied when `num_bits < 64`, missing the case where `offset_extra_bits > 0`. Fixed by masking when `num_bits < 64 or offset_extra_bits > 0`.

### Other

- `__slots__ = ()` added to generated Structure subclasses (generator template + 10 golden files). Reduces instance size from 72 to 48 bytes.
- `Vector.__iter__` uses local variable caching to avoid repeated attribute lookups.
- Removed unnecessary `list()` on dict keys in `Archive.__getattr__`.
- Performance tips section added to `flatdata-py/README.md`.
- Version bump: flatdata-generator and flatdata-py both 0.4.10 → 0.4.11.
- CI workflow updated to install local generator before flatdata-py (`py.yml`).

## Performance

Measured on a vector from a test archive (5.8M elements, 20 fields, 32 bytes each):

| Access pattern | Before | After |
|---|---|---|
| Scalar iteration (1 field) | 9.7s | 5.8s |
| Vectorized column access (1 field) | n/a | 0.07s |
